### PR TITLE
Add vector feature area export script

### DIFF
--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -29,14 +29,6 @@ FID_FIELD = "source_fid"
 HECTARES_PER_SQUARE_METER = 1.0 / 10000.0
 
 
-def _make_output_paths(vector_path: Path, output_dir: Path | None) -> tuple[Path, Path]:
-    """Return timestamped GeoPackage and CSV output paths."""
-    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    output_stem = f"{vector_path.stem}_area_ha_{timestamp}"
-    directory = output_dir if output_dir is not None else vector_path.parent
-    return directory / f"{output_stem}.gpkg", directory / f"{output_stem}.csv"
-
-
 def _ogr_srs_to_pyproj_crs(srs: osr.SpatialReference) -> CRS:
     """Convert an OGR spatial reference to a pyproj CRS."""
     authority_name = srs.GetAuthorityName(None)
@@ -184,7 +176,11 @@ def calculate_vector_area_ha(
     src_layer = src_ds.GetLayer()
     src_srs = src_layer.GetSpatialRef()
     area_ha = _make_area_calculator(src_srs)
-    output_gpkg_path, output_csv_path = _make_output_paths(vector_path, output_dir)
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    output_stem = f"{vector_path.stem}_area_ha_{timestamp}"
+    output_directory = output_dir if output_dir is not None else vector_path.parent
+    output_gpkg_path = output_directory / f"{output_stem}.gpkg"
+    output_csv_path = output_directory / f"{output_stem}.csv"
     output_gpkg_path.parent.mkdir(parents=True, exist_ok=True)
 
     gpkg_driver = ogr.GetDriverByName("GPKG")

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -126,13 +126,11 @@ def _csv_safe_field_value(value):
 
 def calculate_vector_area_ha(
     vector_path: Path,
-    output_dir: Path | None = None,
 ) -> tuple[Path, Path, int]:
     """Write area-annotated vector and CSV outputs for an input vector.
 
     Args:
         vector_path: Path to the input vector dataset.
-        output_dir: Directory where outputs should be written.
 
     Returns:
         Output GeoPackage path, output CSV path, and processed feature count.
@@ -143,7 +141,7 @@ def calculate_vector_area_ha(
     area_ha = _make_area_calculator(src_srs)
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     output_stem = f"{vector_path.stem}_area_ha_{timestamp}"
-    output_directory = output_dir if output_dir is not None else vector_path.parent
+    output_directory = Path.cwd()
     output_gpkg_path = output_directory / f"{output_stem}.gpkg"
     output_csv_path = output_directory / f"{output_stem}.csv"
     output_gpkg_path.parent.mkdir(parents=True, exist_ok=True)
@@ -224,26 +222,10 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Path to an input vector dataset, such as a .shp or .gpkg.",
     )
-    parser.add_argument(
-        "--layer",
-        help="Layer name to read. Defaults to the first layer.",
-    )
-    parser.add_argument(
-        "--layer-index",
-        type=int,
-        default=0,
-        help="Zero-based layer index to read when --layer is not set. Default: 0.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        help="Directory for outputs. Defaults to the input vector directory.",
-    )
     args = parser.parse_args(argv)
 
     output_gpkg_path, output_csv_path, feature_count = calculate_vector_area_ha(
         args.vector_path,
-        output_dir=args.output_dir,
     )
     print(f"Processed {feature_count} feature(s).")
     print(f"Wrote vector: {output_gpkg_path}")

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -107,15 +107,10 @@ def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
     return fieldnames
 
 
-def _safe_text(value: str) -> str:
-    """Replace undecodable legacy text with valid UTF-8 replacement chars."""
-    return value.encode("utf-8", errors="replace").decode("utf-8")
-
-
 def _safe_field_value(value):
     """Make OGR field values safe for UTF-8 CSV and GeoPackage output."""
     if isinstance(value, str):
-        return _safe_text(value)
+        return value.encode("utf-8", errors="replace").decode("utf-8")
     if isinstance(value, list):
         return [_safe_field_value(item) for item in value]
     return value

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -1,0 +1,334 @@
+"""Calculate per-feature polygon area in hectares for a vector layer.
+
+The script reads a vector dataset supported by GDAL/OGR, writes a timestamped
+GeoPackage copy with an ``area_ha`` field, and writes a matching CSV table.
+
+For projected layers, area is computed in the layer's projected units and
+converted to hectares. For geographic layers, polygon area is computed
+geodesically on the CRS ellipsoid so degree-based coordinates are handled
+correctly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from datetime import datetime
+from pathlib import Path
+import sys
+
+from osgeo import gdal, ogr, osr
+from pyproj import CRS, Geod
+from shapely import wkb
+from shapely.geometry.base import BaseGeometry
+
+gdal.UseExceptions()
+
+AREA_FIELD = "area_ha"
+FID_FIELD = "source_fid"
+HECTARES_PER_SQUARE_METER = 1.0 / 10000.0
+
+
+def _open_layer(vector_path: Path, layer_name: str | None, layer_index: int):
+    """Open a vector layer from ``vector_path``."""
+    ds = gdal.OpenEx(str(vector_path), gdal.OF_VECTOR)
+    if ds is None:
+        raise RuntimeError(f"Could not open vector dataset: {vector_path}")
+
+    if layer_name is not None:
+        layer = ds.GetLayerByName(layer_name)
+        if layer is None:
+            available = [ds.GetLayer(i).GetName() for i in range(ds.GetLayerCount())]
+            raise RuntimeError(
+                f"Layer '{layer_name}' not found in {vector_path}. "
+                f"Available layers: {available}"
+            )
+    else:
+        layer = ds.GetLayer(layer_index)
+        if layer is None:
+            raise RuntimeError(
+                f"Layer index {layer_index} not found in {vector_path}; "
+                f"dataset has {ds.GetLayerCount()} layer(s)."
+            )
+
+    return ds, layer
+
+
+def _make_output_paths(vector_path: Path, output_dir: Path | None) -> tuple[Path, Path]:
+    """Return timestamped GeoPackage and CSV output paths."""
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    output_stem = f"{vector_path.stem}_area_ha_{timestamp}"
+    directory = output_dir if output_dir is not None else vector_path.parent
+    return directory / f"{output_stem}.gpkg", directory / f"{output_stem}.csv"
+
+
+def _ogr_srs_to_pyproj_crs(srs: osr.SpatialReference) -> CRS:
+    """Convert an OGR spatial reference to a pyproj CRS."""
+    authority_name = srs.GetAuthorityName(None)
+    authority_code = srs.GetAuthorityCode(None)
+    if authority_name and authority_code:
+        return CRS.from_user_input(f"{authority_name}:{authority_code}")
+    return CRS.from_wkt(srs.ExportToWkt())
+
+
+def _make_area_calculator(srs: osr.SpatialReference):
+    """Create a function that returns area in hectares for an OGR geometry."""
+    if srs is None:
+        raise RuntimeError(
+            "Input layer has no CRS. Area cannot be calculated safely because "
+            "the coordinate units are unknown."
+        )
+
+    if srs.IsProjected():
+        meters_per_unit = srs.GetLinearUnits()
+        if not meters_per_unit:
+            raise RuntimeError("Projected CRS does not report linear units.")
+        sq_meters_per_sq_unit = meters_per_unit * meters_per_unit
+
+        def projected_area_ha(geom: ogr.Geometry) -> float:
+            return abs(geom.GetArea()) * sq_meters_per_sq_unit * HECTARES_PER_SQUARE_METER
+
+        return projected_area_ha
+
+    if srs.IsGeographic():
+        crs = _ogr_srs_to_pyproj_crs(srs)
+        geod = crs.get_geod()
+        if geod is None:
+            ellipsoid = crs.ellipsoid
+            if ellipsoid.semi_major_metre and ellipsoid.inverse_flattening:
+                geod = Geod(
+                    a=ellipsoid.semi_major_metre,
+                    rf=ellipsoid.inverse_flattening,
+                )
+            else:
+                geod = Geod(ellps="WGS84")
+
+        def geographic_area_ha(geom: ogr.Geometry) -> float:
+            shapely_geom: BaseGeometry = wkb.loads(bytes(geom.ExportToWkb()))
+            area_m2, _ = geod.geometry_area_perimeter(shapely_geom)
+            return abs(area_m2) * HECTARES_PER_SQUARE_METER
+
+        return geographic_area_ha
+
+    raise RuntimeError(
+        "Input layer CRS is neither projected nor geographic. "
+        "Please reproject the layer to an equal-area CRS first."
+    )
+
+
+def _copy_schema_with_area_field(src_layer: ogr.Layer, dst_layer: ogr.Layer) -> None:
+    """Copy source fields and add ``area_ha`` when it is absent."""
+    src_defn = src_layer.GetLayerDefn()
+    has_area_field = False
+
+    for i in range(src_defn.GetFieldCount()):
+        field_defn = src_defn.GetFieldDefn(i)
+        if field_defn.GetName() == AREA_FIELD:
+            has_area_field = True
+        dst_layer.CreateField(field_defn)
+
+    if not has_area_field:
+        area_defn = ogr.FieldDefn(AREA_FIELD, ogr.OFTReal)
+        area_defn.SetWidth(32)
+        area_defn.SetPrecision(10)
+        dst_layer.CreateField(area_defn)
+
+
+def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
+    """Build CSV field order with area first, then FID and source fields."""
+    src_defn = src_layer.GetLayerDefn()
+    fieldnames = [AREA_FIELD, FID_FIELD]
+    for i in range(src_defn.GetFieldCount()):
+        name = src_defn.GetFieldDefn(i).GetName()
+        if name == AREA_FIELD:
+            continue
+        if name == FID_FIELD:
+            continue
+        fieldnames.append(name)
+    return fieldnames
+
+
+def _output_geometry_type(src_layer: ogr.Layer) -> int:
+    """Return a permissive output geometry type for mixed polygon datasets."""
+    geom_type = src_layer.GetGeomType()
+    flat_geom_type = ogr.GT_Flatten(geom_type)
+
+    if flat_geom_type == ogr.wkbPolygon:
+        return ogr.wkbMultiPolygon
+    if flat_geom_type == ogr.wkbLineString:
+        return ogr.wkbMultiLineString
+    if flat_geom_type == ogr.wkbPoint:
+        return ogr.wkbMultiPoint
+    return geom_type
+
+
+def _promote_geometry_if_needed(geom: ogr.Geometry, dst_geom_type: int) -> ogr.Geometry:
+    """Promote single-part geometries when the output layer is multi-part."""
+    flat_src_type = ogr.GT_Flatten(geom.GetGeometryType())
+    flat_dst_type = ogr.GT_Flatten(dst_geom_type)
+
+    if flat_src_type == ogr.wkbPolygon and flat_dst_type == ogr.wkbMultiPolygon:
+        multi_geom = ogr.Geometry(ogr.wkbMultiPolygon)
+        multi_geom.AddGeometry(geom)
+        return multi_geom
+    if flat_src_type == ogr.wkbLineString and flat_dst_type == ogr.wkbMultiLineString:
+        multi_geom = ogr.Geometry(ogr.wkbMultiLineString)
+        multi_geom.AddGeometry(geom)
+        return multi_geom
+    if flat_src_type == ogr.wkbPoint and flat_dst_type == ogr.wkbMultiPoint:
+        multi_geom = ogr.Geometry(ogr.wkbMultiPoint)
+        multi_geom.AddGeometry(geom)
+        return multi_geom
+    return geom
+
+
+def _safe_text(value: str) -> str:
+    """Replace undecodable legacy text with valid UTF-8 replacement chars."""
+    return value.encode("utf-8", errors="replace").decode("utf-8")
+
+
+def _safe_field_value(value):
+    """Make OGR field values safe for UTF-8 CSV and GeoPackage output."""
+    if isinstance(value, str):
+        return _safe_text(value)
+    if isinstance(value, list):
+        return [_safe_field_value(item) for item in value]
+    return value
+
+
+def calculate_vector_area_ha(
+    vector_path: Path,
+    output_dir: Path | None = None,
+    layer_name: str | None = None,
+    layer_index: int = 0,
+) -> tuple[Path, Path, int]:
+    """Write a GeoPackage and CSV with per-feature area in hectares."""
+    vector_path = vector_path.resolve()
+    if output_dir is not None:
+        output_dir = output_dir.resolve()
+
+    src_ds, src_layer = _open_layer(vector_path, layer_name, layer_index)
+    src_srs = src_layer.GetSpatialRef()
+    area_ha = _make_area_calculator(src_srs)
+    output_gpkg_path, output_csv_path = _make_output_paths(vector_path, output_dir)
+    output_gpkg_path.parent.mkdir(parents=True, exist_ok=True)
+
+    gpkg_driver = ogr.GetDriverByName("GPKG")
+    if output_gpkg_path.exists():
+        gpkg_driver.DeleteDataSource(str(output_gpkg_path))
+
+    dst_ds = gpkg_driver.CreateDataSource(str(output_gpkg_path))
+    if dst_ds is None:
+        raise RuntimeError(f"Could not create output GeoPackage: {output_gpkg_path}")
+
+    out_layer_name = output_gpkg_path.stem
+    dst_geom_type = _output_geometry_type(src_layer)
+    dst_layer = dst_ds.CreateLayer(
+        out_layer_name,
+        src_srs,
+        dst_geom_type,
+        options=["SPATIAL_INDEX=YES"],
+    )
+    if dst_layer is None:
+        raise RuntimeError(f"Could not create output layer: {out_layer_name}")
+
+    _copy_schema_with_area_field(src_layer, dst_layer)
+    dst_defn = dst_layer.GetLayerDefn()
+    csv_fieldnames = _csv_fieldnames(src_layer)
+    src_defn = src_layer.GetLayerDefn()
+    src_field_names = [
+        src_defn.GetFieldDefn(i).GetName() for i in range(src_defn.GetFieldCount())
+    ]
+
+    feature_count = 0
+    with output_csv_path.open(
+        "w", newline="", encoding="utf-8", errors="replace"
+    ) as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=csv_fieldnames)
+        writer.writeheader()
+
+        src_layer.ResetReading()
+        for src_feature in src_layer:
+            geom = src_feature.GetGeometryRef()
+            if geom is None or geom.IsEmpty():
+                feature_area_ha = 0.0
+                out_geom = None
+            else:
+                geom_clone = geom.Clone()
+                feature_area_ha = area_ha(geom_clone)
+                out_geom = _promote_geometry_if_needed(geom_clone, dst_geom_type)
+
+            dst_feature = ogr.Feature(dst_defn)
+            for field_name in src_field_names:
+                field_value = src_feature.GetField(field_name)
+                if field_value is not None:
+                    dst_feature.SetField(field_name, _safe_field_value(field_value))
+            dst_feature.SetField(AREA_FIELD, float(feature_area_ha))
+            if out_geom is not None:
+                dst_feature.SetGeometry(out_geom)
+            dst_layer.CreateFeature(dst_feature)
+
+            csv_row = {
+                AREA_FIELD: feature_area_ha,
+                FID_FIELD: src_feature.GetFID(),
+            }
+            for field_name in csv_fieldnames[2:]:
+                csv_row[field_name] = _safe_field_value(src_feature.GetField(field_name))
+            writer.writerow(csv_row)
+
+            dst_feature = None
+            feature_count += 1
+
+    dst_ds.FlushCache()
+    dst_ds = None
+    src_ds = None
+    return output_gpkg_path, output_csv_path, feature_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Calculate per-feature area in hectares for a vector layer and "
+            "write timestamped GeoPackage and CSV outputs."
+        )
+    )
+    parser.add_argument(
+        "vector_path",
+        type=Path,
+        help="Path to an input vector dataset, such as a .shp or .gpkg.",
+    )
+    parser.add_argument(
+        "--layer",
+        help="Layer name to read. Defaults to the first layer.",
+    )
+    parser.add_argument(
+        "--layer-index",
+        type=int,
+        default=0,
+        help="Zero-based layer index to read when --layer is not set. Default: 0.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for outputs. Defaults to the input vector directory.",
+    )
+    args = parser.parse_args(argv)
+
+    output_gpkg_path, output_csv_path, feature_count = calculate_vector_area_ha(
+        args.vector_path,
+        output_dir=args.output_dir,
+        layer_name=args.layer,
+        layer_index=args.layer_index,
+    )
+    print(f"Processed {feature_count} feature(s).")
+    print(f"Wrote vector: {output_gpkg_path}")
+    print(f"Wrote CSV: {output_csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import sys
 
 from osgeo import gdal, ogr, osr
-from pyproj import CRS, Geod
+import pyproj
 from shapely import wkb
 from shapely.geometry.base import BaseGeometry
 
@@ -27,15 +27,6 @@ gdal.UseExceptions()
 AREA_FIELD = "area_ha"
 FID_FIELD = "source_fid"
 HECTARES_PER_SQUARE_METER = 1.0 / 10000.0
-
-
-def _ogr_srs_to_pyproj_crs(srs: osr.SpatialReference) -> CRS:
-    """Convert an OGR spatial reference to a pyproj CRS."""
-    authority_name = srs.GetAuthorityName(None)
-    authority_code = srs.GetAuthorityCode(None)
-    if authority_name and authority_code:
-        return CRS.from_user_input(f"{authority_name}:{authority_code}")
-    return CRS.from_wkt(srs.ExportToWkt())
 
 
 def _make_area_calculator(srs: osr.SpatialReference):
@@ -58,17 +49,17 @@ def _make_area_calculator(srs: osr.SpatialReference):
         return projected_area_ha
 
     if srs.IsGeographic():
-        crs = _ogr_srs_to_pyproj_crs(srs)
+        crs = pyproj.CRS.from_wkt(srs.ExportToWkt())
         geod = crs.get_geod()
         if geod is None:
             ellipsoid = crs.ellipsoid
             if ellipsoid.semi_major_metre and ellipsoid.inverse_flattening:
-                geod = Geod(
+                geod = pyproj.Geod(
                     a=ellipsoid.semi_major_metre,
                     rf=ellipsoid.inverse_flattening,
                 )
             else:
-                geod = Geod(ellps="WGS84")
+                geod = pyproj.Geod(ellps="WGS84")
 
         def geographic_area_ha(geom: ogr.Geometry) -> float:
             shapely_geom: BaseGeometry = wkb.loads(bytes(geom.ExportToWkb()))

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -107,12 +107,20 @@ def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
     return fieldnames
 
 
-def _safe_field_value(value):
-    """Make OGR field values safe for UTF-8 CSV and GeoPackage output."""
+def _csv_safe_field_value(value):
+    """Make an OGR field value safe for UTF-8 CSV output.
+
+    Args:
+        value: OGR field value to write to the CSV table.
+
+    Returns:
+        The original value, with strings converted to valid UTF-8 and list
+        values sanitized item by item.
+    """
     if isinstance(value, str):
         return value.encode("utf-8", errors="replace").decode("utf-8")
     if isinstance(value, list):
-        return [_safe_field_value(item) for item in value]
+        return [_csv_safe_field_value(item) for item in value]
     return value
 
 
@@ -186,7 +194,9 @@ def calculate_vector_area_ha(
                 FID_FIELD: source_fid,
             }
             for field_name in csv_fieldnames[2:]:
-                csv_row[field_name] = _safe_field_value(dst_feature.GetField(field_name))
+                csv_row[field_name] = _csv_safe_field_value(
+                    dst_feature.GetField(field_name)
+                )
             writer.writerow(csv_row)
 
             dst_feature = None

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -128,7 +128,15 @@ def calculate_vector_area_ha(
     vector_path: Path,
     output_dir: Path | None = None,
 ) -> tuple[Path, Path, int]:
-    """Write a GeoPackage and CSV with per-feature area in hectares."""
+    """Write area-annotated vector and CSV outputs for an input vector.
+
+    Args:
+        vector_path: Path to the input vector dataset.
+        output_dir: Directory where outputs should be written.
+
+    Returns:
+        Output GeoPackage path, output CSV path, and processed feature count.
+    """
     src_ds = gdal.OpenEx(str(vector_path), gdal.OF_VECTOR)
     src_layer = src_ds.GetLayer()
     src_srs = src_layer.GetSpatialRef()

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -30,7 +30,18 @@ HECTARES_PER_SQUARE_METER = 1.0 / 10000.0
 
 
 def _make_area_calculator(srs: osr.SpatialReference):
-    """Create a function that returns area in hectares for an OGR geometry."""
+    """Create an area calculator for the input layer CRS.
+
+    Args:
+        srs: Spatial reference for the input layer.
+
+    Returns:
+        A callable that accepts an OGR geometry and returns area in hectares.
+
+    Raises:
+        RuntimeError: If the spatial reference is missing or does not describe
+            projected or geographic coordinates.
+    """
     if srs is None:
         raise RuntimeError(
             "Input layer has no CRS. Area cannot be calculated safely because "

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -129,10 +129,6 @@ def calculate_vector_area_ha(
     output_dir: Path | None = None,
 ) -> tuple[Path, Path, int]:
     """Write a GeoPackage and CSV with per-feature area in hectares."""
-    vector_path = vector_path.resolve()
-    if output_dir is not None:
-        output_dir = output_dir.resolve()
-
     src_ds = gdal.OpenEx(str(vector_path), gdal.OF_VECTOR)
     src_layer = src_ds.GetLayer()
     src_srs = src_layer.GetSpatialRef()

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -86,7 +86,15 @@ def _make_area_calculator(srs: osr.SpatialReference):
 
 
 def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
-    """Build CSV field order with area first, then FID and source fields."""
+    """Build the CSV field order for the output table.
+
+    Args:
+        src_layer: Input vector layer whose attribute fields should be copied.
+
+    Returns:
+        CSV field names with ``area_ha`` first, followed by ``source_fid`` and
+        the source attribute fields.
+    """
     src_defn = src_layer.GetLayerDefn()
     fieldnames = [AREA_FIELD, FID_FIELD]
     for i in range(src_defn.GetFieldCount()):

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -85,24 +85,6 @@ def _make_area_calculator(srs: osr.SpatialReference):
     )
 
 
-def _copy_schema_with_area_field(src_layer: ogr.Layer, dst_layer: ogr.Layer) -> None:
-    """Copy source fields and add ``area_ha`` when it is absent."""
-    src_defn = src_layer.GetLayerDefn()
-    has_area_field = False
-
-    for i in range(src_defn.GetFieldCount()):
-        field_defn = src_defn.GetFieldDefn(i)
-        if field_defn.GetName() == AREA_FIELD:
-            has_area_field = True
-        dst_layer.CreateField(field_defn)
-
-    if not has_area_field:
-        area_defn = ogr.FieldDefn(AREA_FIELD, ogr.OFTReal)
-        area_defn.SetWidth(32)
-        area_defn.SetPrecision(10)
-        dst_layer.CreateField(area_defn)
-
-
 def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
     """Build CSV field order with area first, then FID and source fields."""
     src_defn = src_layer.GetLayerDefn()
@@ -115,40 +97,6 @@ def _csv_fieldnames(src_layer: ogr.Layer) -> list[str]:
             continue
         fieldnames.append(name)
     return fieldnames
-
-
-def _output_geometry_type(src_layer: ogr.Layer) -> int:
-    """Return a permissive output geometry type for mixed polygon datasets."""
-    geom_type = src_layer.GetGeomType()
-    flat_geom_type = ogr.GT_Flatten(geom_type)
-
-    if flat_geom_type == ogr.wkbPolygon:
-        return ogr.wkbMultiPolygon
-    if flat_geom_type == ogr.wkbLineString:
-        return ogr.wkbMultiLineString
-    if flat_geom_type == ogr.wkbPoint:
-        return ogr.wkbMultiPoint
-    return geom_type
-
-
-def _promote_geometry_if_needed(geom: ogr.Geometry, dst_geom_type: int) -> ogr.Geometry:
-    """Promote single-part geometries when the output layer is multi-part."""
-    flat_src_type = ogr.GT_Flatten(geom.GetGeometryType())
-    flat_dst_type = ogr.GT_Flatten(dst_geom_type)
-
-    if flat_src_type == ogr.wkbPolygon and flat_dst_type == ogr.wkbMultiPolygon:
-        multi_geom = ogr.Geometry(ogr.wkbMultiPolygon)
-        multi_geom.AddGeometry(geom)
-        return multi_geom
-    if flat_src_type == ogr.wkbLineString and flat_dst_type == ogr.wkbMultiLineString:
-        multi_geom = ogr.Geometry(ogr.wkbMultiLineString)
-        multi_geom.AddGeometry(geom)
-        return multi_geom
-    if flat_src_type == ogr.wkbPoint and flat_dst_type == ogr.wkbMultiPoint:
-        multi_geom = ogr.Geometry(ogr.wkbMultiPoint)
-        multi_geom.AddGeometry(geom)
-        return multi_geom
-    return geom
 
 
 def _safe_text(value: str) -> str:
@@ -184,6 +132,11 @@ def calculate_vector_area_ha(
     output_gpkg_path = output_directory / f"{output_stem}.gpkg"
     output_csv_path = output_directory / f"{output_stem}.csv"
     output_gpkg_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_fieldnames = _csv_fieldnames(src_layer)
+
+    src_layer.ResetReading()
+    source_fids = [src_feature.GetFID() for src_feature in src_layer]
+    src_layer.ResetReading()
 
     gpkg_driver = ogr.GetDriverByName("GPKG")
     if output_gpkg_path.exists():
@@ -193,24 +146,19 @@ def calculate_vector_area_ha(
     if dst_ds is None:
         raise RuntimeError(f"Could not create output GeoPackage: {output_gpkg_path}")
 
-    out_layer_name = output_gpkg_path.stem
-    dst_geom_type = _output_geometry_type(src_layer)
-    dst_layer = dst_ds.CreateLayer(
-        out_layer_name,
-        src_srs,
-        dst_geom_type,
+    dst_layer = dst_ds.CopyLayer(
+        src_layer,
+        output_gpkg_path.stem,
         options=["SPATIAL_INDEX=YES"],
     )
     if dst_layer is None:
-        raise RuntimeError(f"Could not create output layer: {out_layer_name}")
+        raise RuntimeError(f"Could not create output layer: {output_gpkg_path.stem}")
 
-    _copy_schema_with_area_field(src_layer, dst_layer)
-    dst_defn = dst_layer.GetLayerDefn()
-    csv_fieldnames = _csv_fieldnames(src_layer)
-    src_defn = src_layer.GetLayerDefn()
-    src_field_names = [
-        src_defn.GetFieldDefn(i).GetName() for i in range(src_defn.GetFieldCount())
-    ]
+    if dst_layer.GetLayerDefn().GetFieldIndex(AREA_FIELD) == -1:
+        area_defn = ogr.FieldDefn(AREA_FIELD, ogr.OFTReal)
+        area_defn.SetWidth(32)
+        area_defn.SetPrecision(10)
+        dst_layer.CreateField(area_defn)
 
     feature_count = 0
     with output_csv_path.open(
@@ -219,33 +167,23 @@ def calculate_vector_area_ha(
         writer = csv.DictWriter(csv_file, fieldnames=csv_fieldnames)
         writer.writeheader()
 
-        src_layer.ResetReading()
-        for src_feature in src_layer:
-            geom = src_feature.GetGeometryRef()
+        dst_layer.ResetReading()
+        for dst_feature, source_fid in zip(dst_layer, source_fids):
+            geom = dst_feature.GetGeometryRef()
             if geom is None or geom.IsEmpty():
                 feature_area_ha = 0.0
-                out_geom = None
             else:
-                geom_clone = geom.Clone()
-                feature_area_ha = area_ha(geom_clone)
-                out_geom = _promote_geometry_if_needed(geom_clone, dst_geom_type)
+                feature_area_ha = area_ha(geom)
 
-            dst_feature = ogr.Feature(dst_defn)
-            for field_name in src_field_names:
-                field_value = src_feature.GetField(field_name)
-                if field_value is not None:
-                    dst_feature.SetField(field_name, _safe_field_value(field_value))
             dst_feature.SetField(AREA_FIELD, float(feature_area_ha))
-            if out_geom is not None:
-                dst_feature.SetGeometry(out_geom)
-            dst_layer.CreateFeature(dst_feature)
+            dst_layer.SetFeature(dst_feature)
 
             csv_row = {
                 AREA_FIELD: feature_area_ha,
-                FID_FIELD: src_feature.GetFID(),
+                FID_FIELD: source_fid,
             }
             for field_name in csv_fieldnames[2:]:
-                csv_row[field_name] = _safe_field_value(src_feature.GetField(field_name))
+                csv_row[field_name] = _safe_field_value(dst_feature.GetField(field_name))
             writer.writerow(csv_row)
 
             dst_feature = None
@@ -289,8 +227,6 @@ def main(argv: list[str] | None = None) -> int:
     output_gpkg_path, output_csv_path, feature_count = calculate_vector_area_ha(
         args.vector_path,
         output_dir=args.output_dir,
-        layer_name=args.layer,
-        layer_index=args.layer_index,
     )
     print(f"Processed {feature_count} feature(s).")
     print(f"Wrote vector: {output_gpkg_path}")

--- a/calculate_vector_area_ha.py
+++ b/calculate_vector_area_ha.py
@@ -29,31 +29,6 @@ FID_FIELD = "source_fid"
 HECTARES_PER_SQUARE_METER = 1.0 / 10000.0
 
 
-def _open_layer(vector_path: Path, layer_name: str | None, layer_index: int):
-    """Open a vector layer from ``vector_path``."""
-    ds = gdal.OpenEx(str(vector_path), gdal.OF_VECTOR)
-    if ds is None:
-        raise RuntimeError(f"Could not open vector dataset: {vector_path}")
-
-    if layer_name is not None:
-        layer = ds.GetLayerByName(layer_name)
-        if layer is None:
-            available = [ds.GetLayer(i).GetName() for i in range(ds.GetLayerCount())]
-            raise RuntimeError(
-                f"Layer '{layer_name}' not found in {vector_path}. "
-                f"Available layers: {available}"
-            )
-    else:
-        layer = ds.GetLayer(layer_index)
-        if layer is None:
-            raise RuntimeError(
-                f"Layer index {layer_index} not found in {vector_path}; "
-                f"dataset has {ds.GetLayerCount()} layer(s)."
-            )
-
-    return ds, layer
-
-
 def _make_output_paths(vector_path: Path, output_dir: Path | None) -> tuple[Path, Path]:
     """Return timestamped GeoPackage and CSV output paths."""
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
@@ -199,15 +174,14 @@ def _safe_field_value(value):
 def calculate_vector_area_ha(
     vector_path: Path,
     output_dir: Path | None = None,
-    layer_name: str | None = None,
-    layer_index: int = 0,
 ) -> tuple[Path, Path, int]:
     """Write a GeoPackage and CSV with per-feature area in hectares."""
     vector_path = vector_path.resolve()
     if output_dir is not None:
         output_dir = output_dir.resolve()
 
-    src_ds, src_layer = _open_layer(vector_path, layer_name, layer_index)
+    src_ds = gdal.OpenEx(str(vector_path), gdal.OF_VECTOR)
+    src_layer = src_ds.GetLayer()
     src_srs = src_layer.GetSpatialRef()
     area_ha = _make_area_calculator(src_srs)
     output_gpkg_path, output_csv_path = _make_output_paths(vector_path, output_dir)


### PR DESCRIPTION
## Summary
- Adds `calculate_vector_area_ha.py`, a command-line utility for calculating per-feature area in hectares from the first layer of a vector dataset.
- Writes timestamped GeoPackage and CSV outputs named from the input vector stem into the current working directory.
- Uses projected CRS linear units for projected inputs and geodesic ellipsoid area for geographic inputs so area is not computed in square degrees.

Closes #7.

## Testing
- `python -m py_compile calculate_vector_area_ha.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe calculate_vector_area_ha.py --help`
- `C:\Users\richp\mambaforge\envs\py311\python.exe calculate_vector_area_ha.py data\gz_2010_us_050_00_5m\gz_2010_us_050_00_5m.shp`
- Verified the output CSV starts with `area_ha,source_fid,...` and the output GeoPackage contains 3,221 features with `area_ha` populated.

## Known limitations
- Inputs without a CRS fail fast because area units cannot be determined safely.
- Non-projected/non-geographic CRSs should be reprojected to an appropriate equal-area CRS before use.
- The Census shapefile smoke test emits GDAL warnings for missing local `GDAL_DATA`, mixed polygon/multipolygon features, and legacy DBF text encoding; outputs are still written and verified.