### PR TITLE
Cut and flatten cleaned PAD-US public lands by county

### DIFF
--- a/cut_and_flatten_padus_public_lands_by_county.py
+++ b/cut_and_flatten_padus_public_lands_by_county.py
@@ -24,6 +24,11 @@ N_WORKERS = cpu_count() or 1
 
 
 def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed command-line arguments.
+    """
     parser = argparse.ArgumentParser(
         description=(
             "Cut a cleaned PAD-US public lands layer by county, union each "
@@ -42,6 +47,15 @@ def _require_matching_crs(
     padus_public_lands: gpd.GeoDataFrame,
     counties: gpd.GeoDataFrame,
 ) -> None:
+    """Require the PAD-US and county layers to use the same CRS.
+
+    Args:
+        padus_public_lands: Cleaned PAD-US public lands features.
+        counties: County boundary features.
+
+    Raises:
+        ValueError: If either layer lacks a CRS or the CRS values differ.
+    """
     if padus_public_lands.crs is None:
         raise ValueError("PAD-US public lands input does not define a CRS.")
     if counties.crs is None:
@@ -55,6 +69,16 @@ def _require_matching_crs(
 
 
 def _intersect_to_polygonal_area(public_land_geom, county_geom):
+    """Intersect one public-land geometry with one county geometry.
+
+    Args:
+        public_land_geom: Public-land Shapely geometry to clip.
+        county_geom: County Shapely geometry used as the clip boundary.
+
+    Returns:
+        Polygonal intersection as a MultiPolygon, or None if the intersection
+        is empty, non-polygonal, or has zero area.
+    """
     try:
         intersection = shapely.intersection(public_land_geom, county_geom)
     except GEOSException:
@@ -77,6 +101,20 @@ def _process_county(
     candidate_indexes,
     public_land_geometries,
 ) -> tuple[int, dict | None, Counter]:
+    """Clip and flatten all candidate public-land pieces for one county.
+
+    Args:
+        county_number: Original county row index, used to preserve output order.
+        county_fields: Non-geometry county attributes to copy to the output.
+        county_geom: County Shapely geometry.
+        candidate_indexes: Indexes of public-land geometries whose envelopes
+            intersect the county.
+        public_land_geometries: Array of public-land Shapely geometries.
+
+    Returns:
+        County row index, output feature fields plus geometry when the county
+        has positive-area public-land overlap, and processing counters.
+    """
     stats = Counter()
     county_geom = repair_polygonal_geometry(county_geom)
     if county_geom is None:
@@ -114,6 +152,7 @@ def _process_county(
 
 
 def main() -> None:
+    """Run the county clipping and flattening workflow."""
     args = _parse_args()
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     out_path = OUT_DIR / f"{OUT_STEM}_{timestamp}.gpkg"

--- a/cut_and_flatten_padus_public_lands_by_county.py
+++ b/cut_and_flatten_padus_public_lands_by_county.py
@@ -1,0 +1,206 @@
+"""Cut cleaned PAD-US public lands by county and flatten each county."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from os import cpu_count
+from pathlib import Path
+
+import geopandas as gpd
+import shapely
+from shapely.errors import GEOSException
+from tqdm import tqdm
+
+from geometry_utils import polygonal_multipolygon, repair_polygonal_geometry
+
+COUNTY_VECTOR_PATH = Path("data/tl_2024_us_county_50_states.gpkg")
+OUT_DIR = Path("output")
+OUT_LAYER_NAME = "padus_public_lands_clipped_by_county"
+OUT_STEM = "padus_public_lands_clipped_by_county"
+N_WORKERS = cpu_count() or 1
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cut a cleaned PAD-US public lands layer by county, union each "
+            "county's public lands into one feature, and copy county fields."
+        )
+    )
+    parser.add_argument(
+        "padus_public_lands_path",
+        type=Path,
+        help="Cleaned PAD-US public lands vector to cut by county.",
+    )
+    return parser.parse_args()
+
+
+def _require_matching_crs(
+    padus_public_lands: gpd.GeoDataFrame,
+    counties: gpd.GeoDataFrame,
+) -> None:
+    if padus_public_lands.crs is None:
+        raise ValueError("PAD-US public lands input does not define a CRS.")
+    if counties.crs is None:
+        raise ValueError(f"County vector does not define a CRS: {COUNTY_VECTOR_PATH}")
+    if padus_public_lands.crs != counties.crs:
+        raise ValueError(
+            "PAD-US public lands and county CRS values differ. "
+            "Reproject one input before running this script. "
+            f"PAD-US CRS={padus_public_lands.crs}; county CRS={counties.crs}"
+        )
+
+
+def _intersect_to_polygonal_area(public_land_geom, county_geom):
+    try:
+        intersection = shapely.intersection(public_land_geom, county_geom)
+    except GEOSException:
+        public_land_geom = repair_polygonal_geometry(public_land_geom)
+        county_geom = repair_polygonal_geometry(county_geom)
+        if public_land_geom is None or county_geom is None:
+            return None
+        intersection = shapely.intersection(public_land_geom, county_geom)
+
+    intersection = polygonal_multipolygon(intersection)
+    if intersection is None or intersection.area <= 0:
+        return None
+    return intersection
+
+
+def _process_county(
+    county_number: int,
+    county_fields: dict,
+    county_geom,
+    candidate_indexes,
+    public_land_geometries,
+) -> tuple[int, dict | None, Counter]:
+    stats = Counter()
+    county_geom = repair_polygonal_geometry(county_geom)
+    if county_geom is None:
+        stats["invalid_county_geometry"] += 1
+        return county_number, None, stats
+
+    if len(candidate_indexes) == 0:
+        stats["no_candidate_features"] += 1
+        return county_number, None, stats
+
+    pieces = []
+    for candidate_index in candidate_indexes:
+        public_land_geom = public_land_geometries[candidate_index]
+        intersection = _intersect_to_polygonal_area(public_land_geom, county_geom)
+        if intersection is None:
+            stats["zero_area_intersections"] += 1
+            continue
+        pieces.extend(intersection.geoms)
+
+    if not pieces:
+        stats["empty_county_intersection"] += 1
+        return county_number, None, stats
+
+    flattened = shapely.union_all(pieces)
+    flattened = repair_polygonal_geometry(flattened)
+    if flattened is None or flattened.area <= 0:
+        stats["invalid_flattened_geometry"] += 1
+        return county_number, None, stats
+
+    output_fields = dict(county_fields)
+    output_fields["geometry"] = flattened
+    stats["kept_counties"] += 1
+    stats["intersected_pieces"] += len(pieces)
+    return county_number, output_fields, stats
+
+
+def main() -> None:
+    args = _parse_args()
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    out_path = OUT_DIR / f"{OUT_STEM}_{timestamp}.gpkg"
+
+    step_bar = tqdm(total=5, desc="Cut PAD-US by county", unit="step")
+
+    step_bar.set_description("Read PAD-US public lands")
+    padus_public_lands = gpd.read_file(args.padus_public_lands_path)
+    if padus_public_lands.empty:
+        raise ValueError(f"PAD-US public lands input is empty: {args.padus_public_lands_path}")
+    step_bar.update()
+
+    step_bar.set_description("Read counties")
+    counties = gpd.read_file(COUNTY_VECTOR_PATH)
+    if counties.empty:
+        raise ValueError(f"County vector is empty: {COUNTY_VECTOR_PATH}")
+    step_bar.update()
+
+    step_bar.set_description("Validate CRS")
+    _require_matching_crs(padus_public_lands, counties)
+    step_bar.update()
+
+    step_bar.set_description("Build county jobs")
+    county_geometry_column = counties.geometry.name
+    county_field_names = [
+        field_name for field_name in counties.columns if field_name != county_geometry_column
+    ]
+    public_land_geometries = padus_public_lands.geometry.to_numpy()
+    public_land_index = padus_public_lands.sindex
+    jobs = []
+    for county_number, county_row in counties.iterrows():
+        county_geom = county_row[county_geometry_column]
+        candidate_indexes = public_land_index.query(county_geom, predicate="intersects")
+        jobs.append(
+            (
+                county_number,
+                county_row[county_field_names].to_dict(),
+                county_geom,
+                candidate_indexes,
+                public_land_geometries,
+            )
+        )
+    step_bar.update()
+
+    print(
+        f"Workers={N_WORKERS:,} counties={len(jobs):,} "
+        f"public_land_features={len(padus_public_lands):,}",
+        flush=True,
+    )
+    print(f"Output: {out_path}", flush=True)
+
+    step_bar.set_description("Process counties")
+    all_stats = Counter()
+    output_rows = []
+    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        futures = [executor.submit(_process_county, *job) for job in jobs]
+        for future in tqdm(
+            as_completed(futures),
+            total=len(futures),
+            desc="Cut and flatten counties",
+            unit="county",
+        ):
+            county_number, output_row, stats = future.result()
+            all_stats.update(stats)
+            if output_row is not None:
+                output_rows.append((county_number, output_row))
+
+    output_rows.sort(key=lambda row: row[0])
+    output_gdf = gpd.GeoDataFrame(
+        [row for _, row in output_rows],
+        columns=[*county_field_names, "geometry"],
+        geometry="geometry",
+        crs=padus_public_lands.crs,
+    )
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    output_gdf.to_file(out_path, layer=OUT_LAYER_NAME, driver="GPKG", index=False)
+    step_bar.update()
+    step_bar.close()
+
+    print(
+        "Processing stats: "
+        + " ".join(f"{key}={value:,}" for key, value in all_stats.items()),
+        flush=True,
+    )
+    print(f"Wrote {len(output_gdf):,} county feature(s): {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/cut_and_flatten_padus_public_lands_by_county.py
+++ b/cut_and_flatten_padus_public_lands_by_county.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import geopandas as gpd
 import shapely
-from shapely.errors import GEOSException
 from tqdm import tqdm
 
 from geometry_utils import polygonal_multipolygon, repair_polygonal_geometry
@@ -68,32 +67,6 @@ def _require_matching_crs(
         )
 
 
-def _intersect_to_polygonal_area(public_land_geom, county_geom):
-    """Intersect one public-land geometry with one county geometry.
-
-    Args:
-        public_land_geom: Public-land Shapely geometry to clip.
-        county_geom: County Shapely geometry used as the clip boundary.
-
-    Returns:
-        Polygonal intersection as a MultiPolygon, or None if the intersection
-        is empty, non-polygonal, or has zero area.
-    """
-    try:
-        intersection = shapely.intersection(public_land_geom, county_geom)
-    except GEOSException:
-        public_land_geom = repair_polygonal_geometry(public_land_geom)
-        county_geom = repair_polygonal_geometry(county_geom)
-        if public_land_geom is None or county_geom is None:
-            return None
-        intersection = shapely.intersection(public_land_geom, county_geom)
-
-    intersection = polygonal_multipolygon(intersection)
-    if intersection is None or intersection.area <= 0:
-        return None
-    return intersection
-
-
 def _process_county(
     county_number: int,
     county_fields: dict,
@@ -128,7 +101,8 @@ def _process_county(
     pieces = []
     for candidate_index in candidate_indexes:
         public_land_geom = public_land_geometries[candidate_index]
-        intersection = _intersect_to_polygonal_area(public_land_geom, county_geom)
+        intersection = shapely.intersection(public_land_geom, county_geom)
+        intersection = polygonal_multipolygon(intersection)
         if intersection is None:
             stats["zero_area_intersections"] += 1
             continue

--- a/cut_and_flatten_padus_public_lands_by_county.py
+++ b/cut_and_flatten_padus_public_lands_by_county.py
@@ -118,12 +118,14 @@ def main() -> None:
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     out_path = OUT_DIR / f"{OUT_STEM}_{timestamp}.gpkg"
 
-    step_bar = tqdm(total=5, desc="Cut PAD-US by county", unit="step")
+    step_bar = tqdm(total=6, desc="Cut PAD-US by county", unit="step")
 
     step_bar.set_description("Read PAD-US public lands")
     padus_public_lands = gpd.read_file(args.padus_public_lands_path)
     if padus_public_lands.empty:
-        raise ValueError(f"PAD-US public lands input is empty: {args.padus_public_lands_path}")
+        raise ValueError(
+            f"PAD-US public lands input is empty: {args.padus_public_lands_path}"
+        )
     step_bar.update()
 
     step_bar.set_description("Read counties")
@@ -144,7 +146,12 @@ def main() -> None:
     public_land_geometries = padus_public_lands.geometry.to_numpy()
     public_land_index = padus_public_lands.sindex
     jobs = []
-    for county_number, county_row in counties.iterrows():
+    for county_number, county_row in tqdm(
+        counties.iterrows(),
+        total=len(counties),
+        desc="Build county jobs",
+        unit="county",
+    ):
         county_geom = county_row[county_geometry_column]
         candidate_indexes = public_land_index.query(county_geom, predicate="intersects")
         jobs.append(
@@ -165,7 +172,7 @@ def main() -> None:
     )
     print(f"Output: {out_path}", flush=True)
 
-    step_bar.set_description("Process counties")
+    step_bar.set_description("Process county jobs")
     all_stats = Counter()
     output_rows = []
     with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
@@ -180,7 +187,9 @@ def main() -> None:
             all_stats.update(stats)
             if output_row is not None:
                 output_rows.append((county_number, output_row))
+    step_bar.update()
 
+    step_bar.set_description("Write output")
     output_rows.sort(key=lambda row: row[0])
     output_gdf = gpd.GeoDataFrame(
         [row for _, row in output_rows],

--- a/cut_and_flatten_padus_public_lands_by_county.py
+++ b/cut_and_flatten_padus_public_lands_by_county.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
 from os import cpu_count
 from pathlib import Path
@@ -70,37 +70,36 @@ def _require_matching_crs(
 def _process_county(
     county_number: int,
     county_fields: dict,
-    county_geom,
-    candidate_indexes,
-    public_land_geometries,
+    county_geom_wkb: bytes,
+    candidate_wkbs: list[bytes],
 ) -> tuple[int, dict | None, Counter]:
     """Clip and flatten all candidate public-land pieces for one county.
 
     Args:
         county_number: Original county row index, used to preserve output order.
         county_fields: Non-geometry county attributes to copy to the output.
-        county_geom: County Shapely geometry.
-        candidate_indexes: Indexes of public-land geometries whose envelopes
+        county_geom_wkb: County geometry WKB.
+        candidate_wkbs: Public-land geometry WKB values whose envelopes
             intersect the county.
-        public_land_geometries: Array of public-land Shapely geometries.
 
     Returns:
         County row index, output feature fields plus geometry when the county
         has positive-area public-land overlap, and processing counters.
     """
     stats = Counter()
+    county_geom = shapely.from_wkb(county_geom_wkb)
     county_geom = repair_polygonal_geometry(county_geom)
     if county_geom is None:
         stats["invalid_county_geometry"] += 1
         return county_number, None, stats
 
-    if len(candidate_indexes) == 0:
+    if not candidate_wkbs:
         stats["no_candidate_features"] += 1
         return county_number, None, stats
 
     pieces = []
-    for candidate_index in candidate_indexes:
-        public_land_geom = public_land_geometries[candidate_index]
+    for candidate_wkb in candidate_wkbs:
+        public_land_geom = shapely.from_wkb(candidate_wkb)
         intersection = shapely.intersection(public_land_geom, county_geom)
         intersection = polygonal_multipolygon(intersection)
         if intersection is None:
@@ -119,7 +118,7 @@ def _process_county(
         return county_number, None, stats
 
     output_fields = dict(county_fields)
-    output_fields["geometry"] = flattened
+    output_fields["geometry"] = shapely.to_wkb(flattened)
     stats["kept_counties"] += 1
     stats["intersected_pieces"] += len(pieces)
     return county_number, output_fields, stats
@@ -156,7 +155,7 @@ def main() -> None:
     county_field_names = [
         field_name for field_name in counties.columns if field_name != county_geometry_column
     ]
-    public_land_geometries = padus_public_lands.geometry.to_numpy()
+    public_land_wkbs = padus_public_lands.geometry.to_wkb()
     public_land_index = padus_public_lands.sindex
     jobs = []
     for county_number, county_row in tqdm(
@@ -167,13 +166,13 @@ def main() -> None:
     ):
         county_geom = county_row[county_geometry_column]
         candidate_indexes = public_land_index.query(county_geom, predicate="intersects")
+        candidate_wkbs = public_land_wkbs.iloc[candidate_indexes].tolist()
         jobs.append(
             (
                 county_number,
                 county_row[county_field_names].to_dict(),
-                county_geom,
-                candidate_indexes,
-                public_land_geometries,
+                shapely.to_wkb(county_geom),
+                candidate_wkbs,
             )
         )
     step_bar.update()
@@ -188,7 +187,7 @@ def main() -> None:
     step_bar.set_description("Process county jobs")
     all_stats = Counter()
     output_rows = []
-    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+    with ProcessPoolExecutor(max_workers=N_WORKERS) as executor:
         futures = [executor.submit(_process_county, *job) for job in jobs]
         for future in tqdm(
             as_completed(futures),
@@ -204,8 +203,14 @@ def main() -> None:
 
     step_bar.set_description("Write output")
     output_rows.sort(key=lambda row: row[0])
+    output_feature_rows = []
+    for _, output_row in output_rows:
+        output_row = dict(output_row)
+        output_row["geometry"] = shapely.from_wkb(output_row["geometry"])
+        output_feature_rows.append(output_row)
+
     output_gdf = gpd.GeoDataFrame(
-        [row for _, row in output_rows],
+        output_feature_rows,
         columns=[*county_field_names, "geometry"],
         geometry="geometry",
         crs=padus_public_lands.crs,

--- a/geometry_utils.py
+++ b/geometry_utils.py
@@ -1,0 +1,70 @@
+"""Shared geometry normalization and repair helpers."""
+
+from __future__ import annotations
+
+import shapely
+from shapely.geometry import MultiPolygon
+
+
+def polygonal_multipolygon(geom):
+    """Extract polygonal content as a multipolygon.
+
+    Args:
+        geom: Shapely geometry to normalize.
+
+    Returns:
+        A MultiPolygon, or None if no polygonal geometry remains.
+    """
+    if geom is None or geom.is_empty:
+        return None
+
+    if geom.geom_type == "Polygon":
+        parts = [geom]
+    elif geom.geom_type == "MultiPolygon":
+        parts = list(geom.geoms)
+    elif geom.geom_type == "GeometryCollection":
+        parts = []
+        for part in geom.geoms:
+            normalized = polygonal_multipolygon(part)
+            if normalized is not None:
+                parts.extend(normalized.geoms)
+    else:
+        return None
+
+    parts = [part for part in parts if not part.is_empty and part.area > 0]
+    if not parts:
+        return None
+
+    return MultiPolygon(parts)
+
+
+def repair_polygonal_geometry(geom):
+    """Repair and normalize polygon geometry.
+
+    Args:
+        geom: Shapely geometry produced by clipping or overlay.
+
+    Returns:
+        A valid MultiPolygon, or None if repair cannot produce polygonal output.
+    """
+    geom = polygonal_multipolygon(geom)
+    if geom is None:
+        return None
+
+    if geom.is_valid:
+        return geom
+
+    repaired = polygonal_multipolygon(shapely.make_valid(geom))
+    if repaired is not None and repaired.is_valid:
+        return repaired
+
+    if repaired is not None:
+        repaired = polygonal_multipolygon(repaired.buffer(0))
+        if repaired is not None and repaired.is_valid:
+            return repaired
+
+    repaired = polygonal_multipolygon(geom.buffer(0))
+    if repaired is not None and repaired.is_valid:
+        return repaired
+
+    return None

--- a/prepare_padus_public_lands_clipped_to_usa.py
+++ b/prepare_padus_public_lands_clipped_to_usa.py
@@ -12,8 +12,9 @@ from pathlib import Path
 from osgeo import gdal, ogr, osr
 import shapely
 from shapely import wkb
-from shapely.geometry import MultiPolygon
 from tqdm import tqdm
+
+from geometry_utils import repair_polygonal_geometry
 
 gdal.UseExceptions()
 ogr.UseExceptions()
@@ -91,70 +92,6 @@ def _ogr_vertex_count(geom: ogr.Geometry) -> int:
     return count
 
 
-def _polygonal_multipolygon(geom):
-    """Extract polygonal content as a multipolygon.
-
-    Args:
-        geom: Shapely geometry to normalize.
-
-    Returns:
-        A MultiPolygon, or None if no polygonal geometry remains.
-    """
-    if geom is None or geom.is_empty:
-        return None
-
-    if geom.geom_type == "Polygon":
-        parts = [geom]
-    elif geom.geom_type == "MultiPolygon":
-        parts = list(geom.geoms)
-    elif geom.geom_type == "GeometryCollection":
-        parts = []
-        for part in geom.geoms:
-            normalized = _polygonal_multipolygon(part)
-            if normalized is not None:
-                parts.extend(normalized.geoms)
-    else:
-        return None
-
-    parts = [part for part in parts if not part.is_empty and part.area > 0]
-    if not parts:
-        return None
-
-    return MultiPolygon(parts)
-
-
-def _repair_polygonal_geometry(geom):
-    """Repair and normalize clipped polygon geometry.
-
-    Args:
-        geom: Shapely geometry produced by clipping.
-
-    Returns:
-        A valid MultiPolygon, or None if repair cannot produce polygonal output.
-    """
-    geom = _polygonal_multipolygon(geom)
-    if geom is None:
-        return None
-
-    if geom.is_valid:
-        return geom
-
-    repaired = _polygonal_multipolygon(shapely.make_valid(geom))
-    if repaired is not None and repaired.is_valid:
-        return repaired
-
-    if repaired is not None:
-        repaired = _polygonal_multipolygon(repaired.buffer(0))
-        if repaired is not None and repaired.is_valid:
-            return repaired
-
-    repaired = _polygonal_multipolygon(geom.buffer(0))
-    if repaired is not None and repaired.is_valid:
-        return repaired
-
-    return None
-
-
 def _read_usa_boundary(process_srs: osr.SpatialReference):
     """Read, reproject, and merge the USA boundary.
 
@@ -185,7 +122,7 @@ def _read_usa_boundary(process_srs: osr.SpatialReference):
     boundary_vector = None
     boundary_layer = None
     boundary = shapely.union_all(geoms)
-    boundary = _repair_polygonal_geometry(boundary)
+    boundary = repair_polygonal_geometry(boundary)
     if boundary is None:
         raise RuntimeError("USA boundary did not contain valid polygon geometry.")
     return boundary
@@ -320,7 +257,7 @@ def _process_job(
                 geom.Transform(transform)
             shapely_geom = wkb.loads(bytes(geom.ExportToWkb()))
             if not shapely_geom.is_valid:
-                shapely_geom = _repair_polygonal_geometry(shapely_geom)
+                shapely_geom = repair_polygonal_geometry(shapely_geom)
                 if shapely_geom is None:
                     stats["invalid_source_geometry"] += 1
                     failures.append(
@@ -334,7 +271,7 @@ def _process_job(
                 preserve_topology=True,
             )
             clipped = shapely.intersection(simplified, boundary)
-            clipped = _repair_polygonal_geometry(clipped)
+            clipped = repair_polygonal_geometry(clipped)
 
             if clipped is None or clipped.is_empty or clipped.area <= 0:
                 stats["boundary_skipped"] += 1


### PR DESCRIPTION
## Summary
- Add `cut_and_flatten_padus_public_lands_by_county.py` to cut a cleaned PAD-US public lands vector by county, union each county's pieces into one valid multipolygon feature, and copy county attributes.
- Add shared polygonal geometry normalization/repair helpers in `geometry_utils.py`.
- Refactor the existing PAD-US clipping script to use the shared repair helper without changing its workflow.

Closes #17

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile geometry_utils.py prepare_padus_public_lands_clipped_to_usa.py cut_and_flatten_padus_public_lands_by_county.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe cut_and_flatten_padus_public_lands_by_county.py output\smoke_padus_public_lands_matching_county_crs.gpkg`
- Verified smoke output had 1 county feature, county-only attributes, valid `MultiPolygon` geometry, and positive area.
- Ran against `output\padus_public_lands_clipped_to_usa_2026_05_16_17_34_16.gpkg`; it raised the expected CRS mismatch because PAD-US is `ESRI:102039` and counties are `EPSG:4269`.

## Known limitations
- The script intentionally does not reproject inputs. It raises if the cleaned PAD-US layer and county vector CRS values differ.