### PR TITLE
Generate public and all PAD-US clipped land products

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,28 @@
 This repository supports a SNAPP project analyzing ecosystem services over
 public lands in the United States.
 
-## PAD-US Public Lands Preprocessing
+## PAD-US Lands Preprocessing
 
 The PAD-US geodatabase stores short coded values in fields, while GIS software
 may display longer descriptions from coded-value domains. This matters for
 scripts that read the geodatabase directly: filtering should use the stored
 codes, not the displayed descriptions.
 
-The preprocessing script uses:
+The preprocessing script, `prepare_padus_lands_clipped_to_usa.py`, uses:
 
 - Source geodatabase: `data/PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/PADUS4_1Geodatabase.gdb`
 - Source layer: `PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement`
 - USA boundary: `data/usa_vector.gpkg`
-- Output layer name: `padus_public_lands_clipped_to_usa`
-- Output path pattern: `output/padus_public_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg`
 
-The output is a cleaned geometry-only GeoPackage layer. The existence of a
-feature in this output means it passed the public-land filter and was clipped to
-the USA boundary.
+It processes PAD-US geometries once, clips them to the USA boundary, and writes
+two cleaned GeoPackage outputs:
+
+- `output/padus_all_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg`
+- `output/padus_public_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg`
+
+Both outputs strip source PAD-US fields and keep only `land_type` plus geometry.
+The all-lands output writes `land_type = all`. The public-lands output writes
+`land_type = public`.
 
 ## Public-Land Rules
 
@@ -47,4 +51,18 @@ If `Mang_Type` is `UNK` (`Unknown`), keep the feature only when `Own_Type`
 | Joint | `JNT` |
 | State | `STAT` |
 
-All other features are skipped.
+All other features are excluded from the public-lands output, but still appear
+in the all-lands output when their processed geometry has positive-area overlap
+with the USA boundary.
+
+## County Flattening
+
+The `cut_and_flatten_by_county.py` script cuts either clipped lands product by
+county and flattens each county to one multipolygon feature. It copies all
+non-geometry county fields and adds the input `land_type` value to each output
+feature.
+
+Output names are derived from the input product:
+
+- `padus_public_lands_clipped_to_usa_...gpkg` becomes `padus_public_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg`
+- `padus_all_lands_clipped_to_usa_...gpkg` becomes `padus_all_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg`

--- a/cut_and_flatten_by_county.py
+++ b/cut_and_flatten_by_county.py
@@ -67,33 +67,6 @@ def _prepare_counties_crs(
     return counties
 
 
-def _read_input_land_type(input_features: gpd.GeoDataFrame) -> str:
-    """Read the single land type carried by the input features.
-
-    Args:
-        input_features: Input polygon features.
-
-    Returns:
-        The land type value to write to county output features.
-
-    Raises:
-        ValueError: If `land_type` is missing, empty, or mixed.
-    """
-    if "land_type" not in input_features.columns:
-        raise ValueError("Input vector must contain a land_type field.")
-
-    land_types = {
-        land_type
-        for land_type in input_features["land_type"].dropna().unique().tolist()
-        if land_type != ""
-    }
-    if len(land_types) != 1:
-        raise ValueError(
-            "Input vector must contain exactly one non-empty land_type value."
-        )
-    return next(iter(land_types))
-
-
 def _derive_output_names(input_path: Path) -> tuple[str, Path]:
     """Derive the timestamp-free output layer name and output path.
 
@@ -115,19 +88,17 @@ def _derive_output_names(input_path: Path) -> tuple[str, Path]:
 def _process_county(
     county_number: int,
     county_fields: dict,
-    land_type: str,
     county_geom_wkb: bytes,
-    candidate_wkbs: list[bytes],
+    candidate_inputs: list[tuple[bytes, dict]],
 ) -> tuple[int, dict | None, Counter]:
     """Clip and flatten all candidate polygon pieces for one county.
 
     Args:
         county_number: Original county row index, used to preserve output order.
         county_fields: Non-geometry county attributes to copy to the output.
-        land_type: Input land type value to copy to the output.
         county_geom_wkb: County geometry WKB.
-        candidate_wkbs: Input geometry WKB values whose envelopes intersect
-            the county.
+        candidate_inputs: Input geometry WKB values and non-geometry fields
+            whose envelopes intersect the county.
 
     Returns:
         County row index, output feature fields plus geometry when the county
@@ -140,18 +111,21 @@ def _process_county(
         stats["invalid_county_geometry"] += 1
         return county_number, None, stats
 
-    if not candidate_wkbs:
+    if not candidate_inputs:
         stats["no_candidate_features"] += 1
         return county_number, None, stats
 
     pieces = []
-    for candidate_wkb in candidate_wkbs:
+    input_fields = None
+    for candidate_wkb, candidate_fields in candidate_inputs:
         input_geom = shapely.from_wkb(candidate_wkb)
         intersection = shapely.intersection(input_geom, county_geom)
         intersection = polygonal_multipolygon(intersection)
         if intersection is None:
             stats["zero_area_intersections"] += 1
             continue
+        if input_fields is None:
+            input_fields = dict(candidate_fields)
         pieces.extend(intersection.geoms)
 
     if not pieces:
@@ -165,7 +139,7 @@ def _process_county(
         return county_number, None, stats
 
     output_fields = dict(county_fields)
-    output_fields["land_type"] = land_type
+    output_fields.update(input_fields)
     output_fields["geometry"] = shapely.to_wkb(flattened)
     stats["kept_counties"] += 1
     stats["intersected_pieces"] += len(pieces)
@@ -183,7 +157,6 @@ def main() -> None:
     input_features = gpd.read_file(args.input_vector_path)
     if input_features.empty:
         raise ValueError(f"Input vector is empty: {args.input_vector_path}")
-    land_type = _read_input_land_type(input_features)
     step_bar.update()
 
     step_bar.set_description("Read counties")
@@ -201,7 +174,14 @@ def main() -> None:
     county_field_names = [
         field_name for field_name in counties.columns if field_name != county_geometry_column
     ]
+    input_geometry_column = input_features.geometry.name
+    input_field_names = [
+        field_name
+        for field_name in input_features.columns
+        if field_name != input_geometry_column
+    ]
     input_wkbs = input_features.geometry.to_wkb()
+    input_field_rows = input_features[input_field_names].to_dict(orient="records")
     input_index = input_features.sindex
     jobs = []
     for county_number, county_row in tqdm(
@@ -212,14 +192,16 @@ def main() -> None:
     ):
         county_geom = county_row[county_geometry_column]
         candidate_indexes = input_index.query(county_geom, predicate="intersects")
-        candidate_wkbs = input_wkbs.iloc[candidate_indexes].tolist()
+        candidate_inputs = [
+            (input_wkbs.iloc[candidate_index], input_field_rows[candidate_index])
+            for candidate_index in candidate_indexes
+        ]
         jobs.append(
             (
                 county_number,
                 county_row[county_field_names].to_dict(),
-                land_type,
                 shapely.to_wkb(county_geom),
-                candidate_wkbs,
+                candidate_inputs,
             )
         )
     step_bar.update()
@@ -258,7 +240,7 @@ def main() -> None:
 
     output_gdf = gpd.GeoDataFrame(
         output_feature_rows,
-        columns=[*county_field_names, "land_type", "geometry"],
+        columns=[*county_field_names, *input_field_names, "geometry"],
         geometry="geometry",
         crs=input_features.crs,
     )

--- a/cut_and_flatten_by_county.py
+++ b/cut_and_flatten_by_county.py
@@ -1,4 +1,4 @@
-"""Cut cleaned PAD-US public lands by county and flatten each county."""
+"""Cut polygon features by county and flatten each county."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
 from os import cpu_count
 from pathlib import Path
+import re
 
 import geopandas as gpd
 import shapely
@@ -17,9 +18,8 @@ from geometry_utils import polygonal_multipolygon, repair_polygonal_geometry
 
 COUNTY_VECTOR_PATH = Path("data/tl_2024_us_county_50_states.gpkg")
 OUT_DIR = Path("output")
-OUT_LAYER_NAME = "padus_public_lands_clipped_by_county"
-OUT_STEM = "padus_public_lands_clipped_by_county"
 N_WORKERS = cpu_count() or 1
+TIMESTAMP_SUFFIX = re.compile(r"_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}$")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -30,61 +30,108 @@ def _parse_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(
         description=(
-            "Cut a cleaned PAD-US public lands layer by county, union each "
-            "county's public lands into one feature, and copy county fields."
+            "Cut a polygon layer by county, union each county's pieces into "
+            "one feature, and copy county fields."
         )
     )
     parser.add_argument(
-        "padus_public_lands_path",
+        "input_vector_path",
         type=Path,
-        help="Cleaned PAD-US public lands vector to cut by county.",
+        help="Polygon vector to cut by county.",
     )
     return parser.parse_args()
 
 
 def _prepare_counties_crs(
-    padus_public_lands: gpd.GeoDataFrame,
+    input_features: gpd.GeoDataFrame,
     counties: gpd.GeoDataFrame,
 ) -> gpd.GeoDataFrame:
-    """Transform counties to the PAD-US CRS when needed.
+    """Transform counties to the input CRS when needed.
 
     Args:
-        padus_public_lands: Cleaned PAD-US public lands features.
+        input_features: Input polygon features.
         counties: County boundary features.
 
     Returns:
-        County boundary features in the PAD-US CRS.
+        County boundary features in the input CRS.
 
     Raises:
         ValueError: If either layer lacks a CRS.
     """
-    if padus_public_lands.crs is None:
-        raise ValueError("PAD-US public lands input does not define a CRS.")
+    if input_features.crs is None:
+        raise ValueError("Input vector does not define a CRS.")
     if counties.crs is None:
         raise ValueError(f"County vector does not define a CRS: {COUNTY_VECTOR_PATH}")
-    if padus_public_lands.crs != counties.crs:
-        return counties.to_crs(padus_public_lands.crs)
+    if input_features.crs != counties.crs:
+        return counties.to_crs(input_features.crs)
     return counties
+
+
+def _read_input_land_type(input_features: gpd.GeoDataFrame) -> str:
+    """Read the single land type carried by the input features.
+
+    Args:
+        input_features: Input polygon features.
+
+    Returns:
+        The land type value to write to county output features.
+
+    Raises:
+        ValueError: If `land_type` is missing, empty, or mixed.
+    """
+    if "land_type" not in input_features.columns:
+        raise ValueError("Input vector must contain a land_type field.")
+
+    land_types = {
+        land_type
+        for land_type in input_features["land_type"].dropna().unique().tolist()
+        if land_type != ""
+    }
+    if len(land_types) != 1:
+        raise ValueError(
+            "Input vector must contain exactly one non-empty land_type value."
+        )
+    return next(iter(land_types))
+
+
+def _derive_output_names(input_path: Path) -> tuple[str, Path]:
+    """Derive the timestamp-free output layer name and output path.
+
+    Args:
+        input_path: Input vector path.
+
+    Returns:
+        Output layer name and timestamped output path.
+    """
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    input_stem = TIMESTAMP_SUFFIX.sub("", input_path.stem)
+    if "_clipped_to_usa" in input_stem:
+        out_stem = input_stem.replace("_clipped_to_usa", "_clipped_by_county")
+    else:
+        out_stem = f"{input_stem}_clipped_by_county"
+    return out_stem, OUT_DIR / f"{out_stem}_{timestamp}.gpkg"
 
 
 def _process_county(
     county_number: int,
     county_fields: dict,
+    land_type: str,
     county_geom_wkb: bytes,
     candidate_wkbs: list[bytes],
 ) -> tuple[int, dict | None, Counter]:
-    """Clip and flatten all candidate public-land pieces for one county.
+    """Clip and flatten all candidate polygon pieces for one county.
 
     Args:
         county_number: Original county row index, used to preserve output order.
         county_fields: Non-geometry county attributes to copy to the output.
+        land_type: Input land type value to copy to the output.
         county_geom_wkb: County geometry WKB.
-        candidate_wkbs: Public-land geometry WKB values whose envelopes
-            intersect the county.
+        candidate_wkbs: Input geometry WKB values whose envelopes intersect
+            the county.
 
     Returns:
         County row index, output feature fields plus geometry when the county
-        has positive-area public-land overlap, and processing counters.
+        has positive-area input overlap, and processing counters.
     """
     stats = Counter()
     county_geom = shapely.from_wkb(county_geom_wkb)
@@ -99,8 +146,8 @@ def _process_county(
 
     pieces = []
     for candidate_wkb in candidate_wkbs:
-        public_land_geom = shapely.from_wkb(candidate_wkb)
-        intersection = shapely.intersection(public_land_geom, county_geom)
+        input_geom = shapely.from_wkb(candidate_wkb)
+        intersection = shapely.intersection(input_geom, county_geom)
         intersection = polygonal_multipolygon(intersection)
         if intersection is None:
             stats["zero_area_intersections"] += 1
@@ -118,6 +165,7 @@ def _process_county(
         return county_number, None, stats
 
     output_fields = dict(county_fields)
+    output_fields["land_type"] = land_type
     output_fields["geometry"] = shapely.to_wkb(flattened)
     stats["kept_counties"] += 1
     stats["intersected_pieces"] += len(pieces)
@@ -127,17 +175,15 @@ def _process_county(
 def main() -> None:
     """Run the county clipping and flattening workflow."""
     args = _parse_args()
-    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    out_path = OUT_DIR / f"{OUT_STEM}_{timestamp}.gpkg"
+    out_layer_name, out_path = _derive_output_names(args.input_vector_path)
 
-    step_bar = tqdm(total=6, desc="Cut PAD-US by county", unit="step")
+    step_bar = tqdm(total=6, desc="Cut input by county", unit="step")
 
-    step_bar.set_description("Read PAD-US public lands")
-    padus_public_lands = gpd.read_file(args.padus_public_lands_path)
-    if padus_public_lands.empty:
-        raise ValueError(
-            f"PAD-US public lands input is empty: {args.padus_public_lands_path}"
-        )
+    step_bar.set_description("Read input features")
+    input_features = gpd.read_file(args.input_vector_path)
+    if input_features.empty:
+        raise ValueError(f"Input vector is empty: {args.input_vector_path}")
+    land_type = _read_input_land_type(input_features)
     step_bar.update()
 
     step_bar.set_description("Read counties")
@@ -147,7 +193,7 @@ def main() -> None:
     step_bar.update()
 
     step_bar.set_description("Prepare county CRS")
-    counties = _prepare_counties_crs(padus_public_lands, counties)
+    counties = _prepare_counties_crs(input_features, counties)
     step_bar.update()
 
     step_bar.set_description("Build county jobs")
@@ -155,8 +201,8 @@ def main() -> None:
     county_field_names = [
         field_name for field_name in counties.columns if field_name != county_geometry_column
     ]
-    public_land_wkbs = padus_public_lands.geometry.to_wkb()
-    public_land_index = padus_public_lands.sindex
+    input_wkbs = input_features.geometry.to_wkb()
+    input_index = input_features.sindex
     jobs = []
     for county_number, county_row in tqdm(
         counties.iterrows(),
@@ -165,12 +211,13 @@ def main() -> None:
         unit="county",
     ):
         county_geom = county_row[county_geometry_column]
-        candidate_indexes = public_land_index.query(county_geom, predicate="intersects")
-        candidate_wkbs = public_land_wkbs.iloc[candidate_indexes].tolist()
+        candidate_indexes = input_index.query(county_geom, predicate="intersects")
+        candidate_wkbs = input_wkbs.iloc[candidate_indexes].tolist()
         jobs.append(
             (
                 county_number,
                 county_row[county_field_names].to_dict(),
+                land_type,
                 shapely.to_wkb(county_geom),
                 candidate_wkbs,
             )
@@ -179,7 +226,7 @@ def main() -> None:
 
     print(
         f"Workers={N_WORKERS:,} counties={len(jobs):,} "
-        f"public_land_features={len(padus_public_lands):,}",
+        f"input_features={len(input_features):,}",
         flush=True,
     )
     print(f"Output: {out_path}", flush=True)
@@ -211,13 +258,13 @@ def main() -> None:
 
     output_gdf = gpd.GeoDataFrame(
         output_feature_rows,
-        columns=[*county_field_names, "geometry"],
+        columns=[*county_field_names, "land_type", "geometry"],
         geometry="geometry",
-        crs=padus_public_lands.crs,
+        crs=input_features.crs,
     )
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    output_gdf.to_file(out_path, layer=OUT_LAYER_NAME, driver="GPKG", index=False)
+    output_gdf.to_file(out_path, layer=out_layer_name, driver="GPKG", index=False)
     step_bar.update()
     step_bar.close()
 

--- a/prepare_padus_lands_clipped_to_usa.py
+++ b/prepare_padus_lands_clipped_to_usa.py
@@ -1,4 +1,4 @@
-"""Prepare a cleaned PAD-US public lands layer clipped to a USA boundary."""
+"""Prepare cleaned PAD-US land layers clipped to a USA boundary."""
 
 from __future__ import annotations
 
@@ -30,8 +30,11 @@ USA_BOUNDARY_PATH = Path(
 )
 
 OUT_DIR = Path("output")
-OUT_LAYER_NAME = "padus_public_lands_clipped_to_usa"
-OUT_STEM = "padus_public_lands_clipped_to_usa"
+PUBLIC_OUT_LAYER_NAME = "padus_public_lands_clipped_to_usa"
+PUBLIC_OUT_STEM = "padus_public_lands_clipped_to_usa"
+ALL_OUT_LAYER_NAME = "padus_all_lands_clipped_to_usa"
+ALL_OUT_STEM = "padus_all_lands_clipped_to_usa"
+FAILURE_STEM = "padus_lands_clipped_to_usa"
 
 SIMPLIFY_TOLERANCE_METERS = 15.0
 VERTICES_PER_JOB = 10000
@@ -55,14 +58,14 @@ def _set_axis_order(srs: osr.SpatialReference) -> osr.SpatialReference:
     return srs
 
 
-def _feature_should_be_kept(feature: ogr.Feature) -> bool:
-    """Return whether a PAD-US feature passes the owner/manager rules.
+def _feature_is_public(feature: ogr.Feature) -> bool:
+    """Return whether a PAD-US feature passes the public-land rules.
 
     Args:
         feature: PAD-US source feature.
 
     Returns:
-        True if the feature should be considered for geometry processing.
+        True if the feature should be included in the public-land output.
     """
     mang_type = feature.GetField("Mang_Type")
     if mang_type in KEEP_MANG_TYPES:
@@ -154,10 +157,6 @@ def _build_jobs(layer: ogr.Layer, boundary) -> tuple[list[list[int]], Counter]:
     ):
         stats["scanned"] += 1
 
-        if not _feature_should_be_kept(feature):
-            stats["attribute_skipped"] += 1
-            continue
-
         geom = feature.GetGeometryRef()
         if geom is None or geom.IsEmpty():
             stats["empty_geometry_skipped"] += 1
@@ -178,6 +177,8 @@ def _build_jobs(layer: ogr.Layer, boundary) -> tuple[list[list[int]], Counter]:
         current_vertices += feature_vertices
         stats["candidate_features"] += 1
         stats["candidate_vertices"] += feature_vertices
+        if _feature_is_public(feature):
+            stats["public_candidate_features"] += 1
 
         if current_vertices >= VERTICES_PER_JOB:
             jobs.append(current_job)
@@ -223,19 +224,21 @@ def _init_worker(
 
 def _process_job(
     fids: list[int],
-) -> tuple[list[bytes], Counter, list[dict[str, str]]]:
+) -> tuple[list[bytes], list[bytes], Counter, list[dict[str, str]]]:
     """Process a chunk of PAD-US FIDs.
 
     Args:
         fids: Source feature IDs to process.
 
     Returns:
-        Output geometry WKB values, processing counters, and repair-failure rows.
+        All-land output WKB values, public-land output WKB values, processing
+        counters, and repair-failure rows.
     """
     layer = WORKER["layer"]
     transform = WORKER["transform"]
     boundary = WORKER["boundary"]
-    out_wkbs = []
+    all_out_wkbs = []
+    public_out_wkbs = []
     failures = []
     stats = Counter()
 
@@ -277,23 +280,29 @@ def _process_job(
                 stats["boundary_skipped"] += 1
                 continue
 
-            out_wkbs.append(wkb.dumps(clipped))
-            stats["kept"] += 1
+            clipped_wkb = wkb.dumps(clipped)
+            all_out_wkbs.append(clipped_wkb)
+            stats["all_kept"] += 1
+            if _feature_is_public(feature):
+                public_out_wkbs.append(clipped_wkb)
+                stats["public_kept"] += 1
         except Exception as error:
             stats["exceptions"] += 1
             failures.append({"source_fid": fid, "reason": str(error)})
 
-    return out_wkbs, stats, failures
+    return all_out_wkbs, public_out_wkbs, stats, failures
 
 
 def _create_output_layer(
     out_path: Path,
+    layer_name: str,
     process_srs: osr.SpatialReference,
 ) -> tuple[ogr.DataSource, ogr.Layer]:
     """Create the output GeoPackage layer.
 
     Args:
         out_path: Output GeoPackage path.
+        layer_name: Output layer name.
         process_srs: Output spatial reference.
 
     Returns:
@@ -305,15 +314,37 @@ def _create_output_layer(
         raise RuntimeError(f"Could not create output GeoPackage: {out_path}")
 
     out_layer = out_ds.CreateLayer(
-        OUT_LAYER_NAME,
+        layer_name,
         process_srs,
         ogr.wkbMultiPolygon,
         options=["SPATIAL_INDEX=YES"],
     )
     if out_layer is None:
-        raise RuntimeError(f"Could not create output layer: {OUT_LAYER_NAME}")
+        raise RuntimeError(f"Could not create output layer: {layer_name}")
+    out_layer.CreateField(ogr.FieldDefn("land_type", ogr.OFTString))
 
     return out_ds, out_layer
+
+
+def _write_geometry_feature(
+    out_layer: ogr.Layer,
+    out_defn: ogr.FeatureDefn,
+    geom_wkb: bytes,
+    land_type: str,
+) -> None:
+    """Write one output geometry with its land type.
+
+    Args:
+        out_layer: Destination OGR layer.
+        out_defn: Destination layer definition.
+        geom_wkb: Output geometry WKB.
+        land_type: Output land-type label.
+    """
+    feature = ogr.Feature(out_defn)
+    feature.SetField("land_type", land_type)
+    feature.SetGeometry(ogr.CreateGeometryFromWkb(geom_wkb))
+    out_layer.CreateFeature(feature)
+    feature = None
 
 
 def _write_failures(failure_path: Path, failures: list[dict[str, str]]) -> None:
@@ -355,8 +386,9 @@ def main() -> None:
     # which will make the load faster then we're fixing it in this script
     # anyway
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    out_path = OUT_DIR / f"{OUT_STEM}_{timestamp}.gpkg"
-    failure_path = OUT_DIR / f"{OUT_STEM}_{timestamp}_skipped.csv"
+    public_out_path = OUT_DIR / f"{PUBLIC_OUT_STEM}_{timestamp}.gpkg"
+    all_out_path = OUT_DIR / f"{ALL_OUT_STEM}_{timestamp}.gpkg"
+    failure_path = OUT_DIR / f"{FAILURE_STEM}_{timestamp}_skipped.csv"
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     step_bar = tqdm(total=5, desc="PAD-US preprocessing", unit="step")
@@ -395,18 +427,30 @@ def main() -> None:
         f"jobs={len(jobs):,}",
         flush=True,
     )
-    print(f"Output: {out_path}", flush=True)
+    print(f"Public output: {public_out_path}", flush=True)
+    print(f"All-lands output: {all_out_path}", flush=True)
     print(f"Failure log: {failure_path}", flush=True)
 
-    step_bar.set_description("Create output")
-    out_ds, out_layer = _create_output_layer(out_path, process_srs)
-    out_defn = out_layer.GetLayerDefn()
+    step_bar.set_description("Create outputs")
+    public_out_ds, public_out_layer = _create_output_layer(
+        public_out_path,
+        PUBLIC_OUT_LAYER_NAME,
+        process_srs,
+    )
+    all_out_ds, all_out_layer = _create_output_layer(
+        all_out_path,
+        ALL_OUT_LAYER_NAME,
+        process_srs,
+    )
+    public_out_defn = public_out_layer.GetLayerDefn()
+    all_out_defn = all_out_layer.GetLayerDefn()
     step_bar.update()
 
     step_bar.set_description("Process jobs")
     all_stats = Counter()
     failures = []
-    written = 0
+    public_written = 0
+    all_written = 0
 
     worker_args = (
         PADUS_GDB_PATH,
@@ -428,19 +472,26 @@ def main() -> None:
             desc="Process PAD-US jobs",
             unit="job",
         ):
-            out_wkbs, stats, job_failures = future.result()
+            all_out_wkbs, public_out_wkbs, stats, job_failures = future.result()
             all_stats.update(stats)
             failures.extend(job_failures)
 
-            for geom_wkb in out_wkbs:
-                feature = ogr.Feature(out_defn)
-                feature.SetGeometry(ogr.CreateGeometryFromWkb(geom_wkb))
-                out_layer.CreateFeature(feature)
-                feature = None
-                written += 1
+            for geom_wkb in all_out_wkbs:
+                _write_geometry_feature(all_out_layer, all_out_defn, geom_wkb, "all")
+                all_written += 1
+            for geom_wkb in public_out_wkbs:
+                _write_geometry_feature(
+                    public_out_layer,
+                    public_out_defn,
+                    geom_wkb,
+                    "public",
+                )
+                public_written += 1
 
-    out_ds.FlushCache()
-    out_ds = None
+    all_out_ds.FlushCache()
+    public_out_ds.FlushCache()
+    all_out_ds = None
+    public_out_ds = None
 
     if failures:
         _write_failures(failure_path, failures)
@@ -453,7 +504,11 @@ def main() -> None:
         + " ".join(f"{key}={value:,}" for key, value in all_stats.items()),
         flush=True,
     )
-    print(f"Wrote {written:,} output feature(s): {out_path}", flush=True)
+    print(f"Wrote {all_written:,} all-land feature(s): {all_out_path}", flush=True)
+    print(
+        f"Wrote {public_written:,} public-land feature(s): {public_out_path}",
+        flush=True,
+    )
     if failures:
         print(f"Wrote {len(failures):,} skipped feature log row(s): {failure_path}")
     else:

--- a/prepare_padus_lands_clipped_to_usa.py
+++ b/prepare_padus_lands_clipped_to_usa.py
@@ -30,9 +30,7 @@ USA_BOUNDARY_PATH = Path(
 )
 
 OUT_DIR = Path("output")
-PUBLIC_OUT_LAYER_NAME = "padus_public_lands_clipped_to_usa"
 PUBLIC_OUT_STEM = "padus_public_lands_clipped_to_usa"
-ALL_OUT_LAYER_NAME = "padus_all_lands_clipped_to_usa"
 ALL_OUT_STEM = "padus_all_lands_clipped_to_usa"
 FAILURE_STEM = "padus_lands_clipped_to_usa"
 
@@ -434,12 +432,12 @@ def main() -> None:
     step_bar.set_description("Create outputs")
     public_out_ds, public_out_layer = _create_output_layer(
         public_out_path,
-        PUBLIC_OUT_LAYER_NAME,
+        PUBLIC_OUT_STEM,
         process_srs,
     )
     all_out_ds, all_out_layer = _create_output_layer(
         all_out_path,
-        ALL_OUT_LAYER_NAME,
+        ALL_OUT_STEM,
         process_srs,
     )
     public_out_defn = public_out_layer.GetLayerDefn()


### PR DESCRIPTION
## Summary
- Rename the PAD-US preprocessing script to `prepare_padus_lands_clipped_to_usa.py` and produce both public-only and all-lands USA-clipped outputs from one geometry-processing pass.
- Add `land_type` to clipped PAD-US outputs and strip other PAD-US source fields.
- Rename the county cutter to `cut_and_flatten_by_county.py`, derive public/all county output names from the input stem, and carry `land_type` into county-flattened outputs.
- Update the README for the new two-product PAD-US workflow.

Closes #21

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile prepare_padus_lands_clipped_to_usa.py cut_and_flatten_by_county.py geometry_utils.py`
- `git diff --check`
- Created smoke clipped-to-USA fixtures for `land_type = all` and `land_type = public`.
- `C:\Users\richp\mambaforge\envs\py311\python.exe cut_and_flatten_by_county.py output\padus_all_lands_clipped_to_usa_2026_05_17_12_00_00.gpkg`
- `C:\Users\richp\mambaforge\envs\py311\python.exe cut_and_flatten_by_county.py output\padus_public_lands_clipped_to_usa_2026_05_17_12_00_00.gpkg`
- Verified both smoke county outputs wrote 1 valid `MultiPolygon` and preserved the expected `land_type` value.

## Known limitations
- I did not run the full PAD-US preprocessing job because it is the large production run; the updated preprocessing script was compile-checked.