### PR TITLE
Generate NLCD reclass masks from workflow tables

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - proj
   - pyproj
   - gdal
+  - rasterio
   - fiona
   - geopandas
   - shapely>=2

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - gdal
   - rasterio
   - fiona
+  - pandas
   - geopandas
   - shapely>=2
   - rtree

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +13,7 @@ from pathlib import Path
 import sys
 
 import numpy as np
+import pandas as pd
 import rasterio
 from tqdm import tqdm
 
@@ -74,39 +74,18 @@ def _read_reclass_table(table_path: Path) -> dict[int, int]:
         ValueError: If the table is empty, missing required columns, contains
             duplicate source IDs, or maps to values other than 0 and 1.
     """
-    with table_path.open(newline="", encoding="utf-8-sig") as table_file:
-        reader = csv.DictReader(table_file)
-        if reader.fieldnames is None:
-            raise ValueError(f"Reclass table is empty: {table_path}")
-        required_fields = {"id", "reclass"}
-        missing_fields = required_fields - set(reader.fieldnames)
-        if missing_fields:
-            missing = ", ".join(sorted(missing_fields))
-            raise ValueError(f"Reclass table {table_path} is missing: {missing}")
-
-        mapping = {}
-        for row_number, row in enumerate(reader, start=2):
-            try:
-                source_value = int(row["id"])
-                mask_value = int(row["reclass"])
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"Table {table_path} has a non-integer value on row {row_number}."
-                ) from exc
-            if mask_value not in {0, 1}:
-                raise ValueError(
-                    f"Table {table_path} row {row_number} maps to {mask_value}; "
-                    "only 0 and 1 are valid mask values."
-                )
-            if source_value in mapping:
-                raise ValueError(
-                    f"Table {table_path} repeats NLCD class {source_value}."
-                )
-            mapping[source_value] = mask_value
-
-    if not mapping:
+    table = pd.read_csv(table_path, usecols=["id", "reclass"])
+    if table.empty:
         raise ValueError(f"Reclass table has no rows: {table_path}")
-    return mapping
+    if table["id"].duplicated().any():
+        duplicated_ids = table.loc[table["id"].duplicated(), "id"].tolist()
+        raise ValueError(f"Table {table_path} repeats NLCD classes: {duplicated_ids}")
+    invalid_values = set(table["reclass"]) - {0, 1}
+    if invalid_values:
+        raise ValueError(
+            f"Table {table_path} maps to invalid mask values: {sorted(invalid_values)}"
+        )
+    return dict(zip(table["id"].astype(int), table["reclass"].astype(int)))
 
 
 def _chunked(iterable, chunk_size: int):

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -97,13 +97,7 @@ def _chunked(iterable, chunk_size: int):
 
     Yields:
         Lists containing up to ``chunk_size`` items.
-
-    Raises:
-        ValueError: If ``chunk_size`` is less than one.
     """
-    if chunk_size < 1:
-        raise ValueError("Chunk size must be at least 1.")
-
     iterator = iter(iterable)
     while True:
         chunk = list(islice(iterator, chunk_size))

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -58,15 +58,6 @@ def _parse_args() -> argparse.Namespace:
         default=cpu_count() or 1,
         help="Number of mask rasters to generate in parallel. Default: CPU count.",
     )
-    parser.add_argument(
-        "--windows-per-progress-update",
-        type=int,
-        default=WINDOWS_PER_PROGRESS_UPDATE,
-        help=(
-            "Number of raster block windows to process before updating each "
-            f"progress bar. Default: {WINDOWS_PER_PROGRESS_UPDATE}."
-        ),
-    )
     return parser.parse_args()
 
 
@@ -190,16 +181,11 @@ def _worker_initializer(lock: RLock) -> None:
     tqdm.set_lock(lock)
 
 
-def _generate_mask(
-    job: MaskJob,
-    windows_per_progress_update: int,
-) -> Path:
+def _generate_mask(job: MaskJob) -> Path:
     """Generate one mask raster from one reclass table.
 
     Args:
         job: Mask generation job metadata.
-        windows_per_progress_update: Number of windows to process between
-            progress-bar updates.
 
     Returns:
         Output raster path.
@@ -231,7 +217,7 @@ def _generate_mask(
                 dynamic_ncols=True,
             ) as progress_bar:
                 for window_batch in _chunked(
-                    block_windows, windows_per_progress_update
+                    block_windows, WINDOWS_PER_PROGRESS_UPDATE
                 ):
                     for _, window in window_batch:
                         source_array = source.read(1, window=window, masked=True)
@@ -286,28 +272,23 @@ def _discover_jobs(
 
 def generate_nlcd_reclass_masks(
     workers: int,
-    windows_per_progress_update: int,
 ) -> list[Path]:
     """Generate all NLCD reclass masks in parallel.
 
     Args:
         workers: Maximum number of parallel worker processes.
-        windows_per_progress_update: Number of block windows processed between
-            each per-mask tqdm update.
 
     Returns:
         Generated output raster paths.
 
     Raises:
         FileNotFoundError: If the source raster does not exist.
-        ValueError: If worker count or window batching settings are invalid.
+        ValueError: If worker count is invalid.
     """
     if not DEFAULT_NLCD_RASTER_PATH.exists():
         raise FileNotFoundError(f"NLCD raster not found: {DEFAULT_NLCD_RASTER_PATH}")
     if workers < 1:
         raise ValueError("Workers must be at least 1.")
-    if windows_per_progress_update < 1:
-        raise ValueError("Windows per progress update must be at least 1.")
 
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     jobs = _discover_jobs(timestamp)
@@ -336,7 +317,6 @@ def generate_nlcd_reclass_masks(
                 executor.submit(
                     _generate_mask,
                     job,
-                    windows_per_progress_update,
                 )
                 for job in jobs
             ]
@@ -352,7 +332,6 @@ def main() -> None:
     args = _parse_args()
     outputs = generate_nlcd_reclass_masks(
         workers=args.workers,
-        windows_per_progress_update=args.windows_per_progress_update,
     )
     print("Generated masks:", flush=True)
     for output in outputs:

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -271,10 +271,10 @@ def generate_nlcd_reclass_masks(
     jobs = _discover_jobs(timestamp)
     worker_count = min(workers, len(jobs))
 
-    print(f"NLCD raster: {DEFAULT_NLCD_RASTER_PATH}", flush=True)
-    print(f"Reclass tables: {DEFAULT_RECLASS_TABLE_DIR}", flush=True)
-    print(f"Output root: {DEFAULT_OUTPUT_DIR}", flush=True)
-    print(f"Workers: {worker_count:,}", flush=True)
+    tqdm.write(f"NLCD raster: {DEFAULT_NLCD_RASTER_PATH}")
+    tqdm.write(f"Reclass tables: {DEFAULT_RECLASS_TABLE_DIR}")
+    tqdm.write(f"Output root: {DEFAULT_OUTPUT_DIR}")
+    tqdm.write(f"Workers: {worker_count:,}")
 
     lock = RLock()
     outputs = []
@@ -310,9 +310,9 @@ def main() -> None:
     outputs = generate_nlcd_reclass_masks(
         workers=args.workers,
     )
-    print("Generated masks:", flush=True)
+    tqdm.write("Generated masks:")
     for output in outputs:
-        print(f"  {output}", flush=True)
+        tqdm.write(f"  {output}")
 
 
 if __name__ == "__main__":

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -1,0 +1,397 @@
+"""Generate NLCD land-cover mask rasters from reclass CSV tables."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import islice
+from multiprocessing import RLock
+from os import cpu_count
+from pathlib import Path
+import sys
+
+import numpy as np
+import rasterio
+from tqdm import tqdm
+
+DEFAULT_NLCD_RASTER_PATH = Path(
+    "data/analysis_inputs/nlcd/Annual_NLCD_LndCov_2023_CU_C1V0.tif"
+)
+DEFAULT_RECLASS_TABLE_DIR = Path("data/workflow_assets/landcover_reclass")
+DEFAULT_OUTPUT_DIR = Path("data/analysis_inputs/masks")
+OUTPUT_NODATA = 255
+WINDOWS_PER_PROGRESS_UPDATE = 100
+
+
+@dataclass(frozen=True)
+class MaskJob:
+    """A single mask raster generation job.
+
+    Args:
+        table_path: Reclass CSV path.
+        output_path: Timestamped output raster path.
+        progress_position: Fixed tqdm terminal row for this job.
+    """
+
+    table_path: Path
+    output_path: Path
+    progress_position: int
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate 0/1/nodata byte masks from every NLCD reclass CSV table."
+        )
+    )
+    parser.add_argument(
+        "--nlcd-raster",
+        type=Path,
+        default=DEFAULT_NLCD_RASTER_PATH,
+        help=f"NLCD land-cover raster path. Default: {DEFAULT_NLCD_RASTER_PATH}",
+    )
+    parser.add_argument(
+        "--reclass-table-dir",
+        type=Path,
+        default=DEFAULT_RECLASS_TABLE_DIR,
+        help=f"Directory containing id,reclass CSV tables. Default: {DEFAULT_RECLASS_TABLE_DIR}",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory where mask subdirectories will be written. Default: {DEFAULT_OUTPUT_DIR}",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=cpu_count() or 1,
+        help="Number of mask rasters to generate in parallel. Default: CPU count.",
+    )
+    parser.add_argument(
+        "--windows-per-progress-update",
+        type=int,
+        default=WINDOWS_PER_PROGRESS_UPDATE,
+        help=(
+            "Number of raster block windows to process before updating each "
+            f"progress bar. Default: {WINDOWS_PER_PROGRESS_UPDATE}."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _read_reclass_table(table_path: Path) -> dict[int, int]:
+    """Read a two-column NLCD reclass table.
+
+    Args:
+        table_path: CSV file with ``id`` and ``reclass`` columns.
+
+    Returns:
+        Mapping from source NLCD integer class to output mask value.
+
+    Raises:
+        ValueError: If the table is empty, missing required columns, contains
+            duplicate source IDs, or maps to values other than 0 and 1.
+    """
+    with table_path.open(newline="", encoding="utf-8-sig") as table_file:
+        reader = csv.DictReader(table_file)
+        if reader.fieldnames is None:
+            raise ValueError(f"Reclass table is empty: {table_path}")
+        required_fields = {"id", "reclass"}
+        missing_fields = required_fields - set(reader.fieldnames)
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise ValueError(f"Reclass table {table_path} is missing: {missing}")
+
+        mapping = {}
+        for row_number, row in enumerate(reader, start=2):
+            try:
+                source_value = int(row["id"])
+                mask_value = int(row["reclass"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Table {table_path} has a non-integer value on row {row_number}."
+                ) from exc
+            if mask_value not in {0, 1}:
+                raise ValueError(
+                    f"Table {table_path} row {row_number} maps to {mask_value}; "
+                    "only 0 and 1 are valid mask values."
+                )
+            if source_value in mapping:
+                raise ValueError(
+                    f"Table {table_path} repeats NLCD class {source_value}."
+                )
+            mapping[source_value] = mask_value
+
+    if not mapping:
+        raise ValueError(f"Reclass table has no rows: {table_path}")
+    return mapping
+
+
+def _chunked(iterable, chunk_size: int):
+    """Yield fixed-size chunks from an iterable.
+
+    Args:
+        iterable: Iterable to chunk.
+        chunk_size: Maximum number of items in each yielded chunk.
+
+    Yields:
+        Lists containing up to ``chunk_size`` items.
+
+    Raises:
+        ValueError: If ``chunk_size`` is less than one.
+    """
+    if chunk_size < 1:
+        raise ValueError("Chunk size must be at least 1.")
+
+    iterator = iter(iterable)
+    while True:
+        chunk = list(islice(iterator, chunk_size))
+        if not chunk:
+            return
+        yield chunk
+
+
+def _build_output_profile(source_profile: dict) -> dict:
+    """Build the output raster profile from the NLCD source profile.
+
+    Args:
+        source_profile: Rasterio profile from the source NLCD raster.
+
+    Returns:
+        Rasterio profile for byte 0/1/nodata mask output.
+    """
+    output_profile = dict(source_profile)
+    output_profile.update(
+        driver="GTiff",
+        count=1,
+        dtype="uint8",
+        nodata=OUTPUT_NODATA,
+        compress="deflate",
+        BIGTIFF="IF_SAFER",
+    )
+    return output_profile
+
+
+def _reclassify_array(source_array: np.ma.MaskedArray, mapping: dict[int, int]) -> np.ndarray:
+    """Convert a source NLCD block to a 0/1/nodata byte mask block.
+
+    Args:
+        source_array: Masked source NLCD block.
+        mapping: Source NLCD class to output mask value.
+
+    Returns:
+        A uint8 array with values 0, 1, or ``OUTPUT_NODATA``.
+    """
+    output = np.full(source_array.shape, OUTPUT_NODATA, dtype=np.uint8)
+    data = np.ma.getdata(source_array)
+    source_mask = np.ma.getmaskarray(source_array)
+    for source_value, mask_value in mapping.items():
+        output[(data == source_value) & ~source_mask] = mask_value
+    return output
+
+
+def _worker_initializer(lock: RLock) -> None:
+    """Initialize tqdm locking inside a worker process.
+
+    Args:
+        lock: Multiprocessing lock shared by tqdm progress bars.
+    """
+    tqdm.set_lock(lock)
+
+
+def _generate_mask(
+    nlcd_raster_path: Path,
+    job: MaskJob,
+    windows_per_progress_update: int,
+) -> Path:
+    """Generate one mask raster from one reclass table.
+
+    Args:
+        nlcd_raster_path: Source NLCD land-cover raster path.
+        job: Mask generation job metadata.
+        windows_per_progress_update: Number of windows to process between
+            progress-bar updates.
+
+    Returns:
+        Output raster path.
+
+    Raises:
+        FileExistsError: If the timestamped output path already exists.
+        ValueError: If the source raster has more than one band.
+    """
+    mapping = _read_reclass_table(job.table_path)
+    job.output_path.parent.mkdir(parents=True, exist_ok=True)
+    if job.output_path.exists():
+        raise FileExistsError(f"Refusing to overwrite existing output: {job.output_path}")
+
+    with rasterio.open(nlcd_raster_path) as source:
+        if source.count != 1:
+            raise ValueError(f"Expected a single-band NLCD raster: {nlcd_raster_path}")
+
+        output_profile = _build_output_profile(source.profile)
+        block_windows = list(source.block_windows(1))
+        with rasterio.open(job.output_path, "w", **output_profile) as destination:
+            with tqdm(
+                total=len(block_windows),
+                desc=job.table_path.stem,
+                unit="block",
+                position=job.progress_position,
+                leave=True,
+                dynamic_ncols=True,
+            ) as progress_bar:
+                for window_batch in _chunked(
+                    block_windows, windows_per_progress_update
+                ):
+                    for _, window in window_batch:
+                        source_array = source.read(1, window=window, masked=True)
+                        output_array = _reclassify_array(source_array, mapping)
+                        destination.write(output_array, 1, window=window)
+                    progress_bar.update(len(window_batch))
+
+    return job.output_path
+
+
+def _discover_jobs(
+    reclass_table_dir: Path,
+    output_dir: Path,
+    timestamp: str,
+) -> list[MaskJob]:
+    """Build mask generation jobs from all CSV tables in a directory.
+
+    Args:
+        reclass_table_dir: Directory containing reclass CSV tables.
+        output_dir: Root output directory for generated masks.
+        timestamp: Timestamp string to add to each output raster stem.
+
+    Returns:
+        One job per CSV table, sorted by table name.
+
+    Raises:
+        FileNotFoundError: If the table directory does not exist.
+        ValueError: If no CSV tables are found.
+    """
+    if not reclass_table_dir.exists():
+        raise FileNotFoundError(f"Reclass table directory not found: {reclass_table_dir}")
+
+    table_paths = sorted(reclass_table_dir.glob("*.csv"))
+    if not table_paths:
+        raise ValueError(f"No CSV reclass tables found in: {reclass_table_dir}")
+
+    jobs = []
+    for position, table_path in enumerate(table_paths, start=1):
+        table_stem = table_path.stem
+        output_path = (
+            output_dir
+            / table_stem
+            / f"reclassified_NLCD2023_{table_stem}_{timestamp}.tif"
+        )
+        jobs.append(
+            MaskJob(
+                table_path=table_path,
+                output_path=output_path,
+                progress_position=position,
+            )
+        )
+    return jobs
+
+
+def generate_nlcd_reclass_masks(
+    nlcd_raster_path: Path,
+    reclass_table_dir: Path,
+    output_dir: Path,
+    workers: int,
+    windows_per_progress_update: int,
+) -> list[Path]:
+    """Generate all NLCD reclass masks in parallel.
+
+    Args:
+        nlcd_raster_path: Source NLCD land-cover raster path.
+        reclass_table_dir: Directory containing ``id,reclass`` CSV tables.
+        output_dir: Root output directory for generated masks.
+        workers: Maximum number of parallel worker processes.
+        windows_per_progress_update: Number of block windows processed between
+            each per-mask tqdm update.
+
+    Returns:
+        Generated output raster paths.
+
+    Raises:
+        FileNotFoundError: If the source raster does not exist.
+        ValueError: If worker count or window batching settings are invalid.
+    """
+    if not nlcd_raster_path.exists():
+        raise FileNotFoundError(f"NLCD raster not found: {nlcd_raster_path}")
+    if workers < 1:
+        raise ValueError("Workers must be at least 1.")
+    if windows_per_progress_update < 1:
+        raise ValueError("Windows per progress update must be at least 1.")
+
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    jobs = _discover_jobs(reclass_table_dir, output_dir, timestamp)
+    worker_count = min(workers, len(jobs))
+
+    print(f"NLCD raster: {nlcd_raster_path}", flush=True)
+    print(f"Reclass tables: {reclass_table_dir}", flush=True)
+    print(f"Output root: {output_dir}", flush=True)
+    print(f"Workers: {worker_count:,}", flush=True)
+
+    lock = RLock()
+    outputs = []
+    with tqdm(
+        total=len(jobs),
+        desc="Completed masks",
+        unit="mask",
+        position=0,
+        dynamic_ncols=True,
+    ) as overall_bar:
+        with ProcessPoolExecutor(
+            max_workers=worker_count,
+            initializer=_worker_initializer,
+            initargs=(lock,),
+        ) as executor:
+            futures = [
+                executor.submit(
+                    _generate_mask,
+                    nlcd_raster_path,
+                    job,
+                    windows_per_progress_update,
+                )
+                for job in jobs
+            ]
+            for future in as_completed(futures):
+                outputs.append(future.result())
+                overall_bar.update()
+
+    return sorted(outputs)
+
+
+def main() -> None:
+    """Run the NLCD mask generation workflow."""
+    args = _parse_args()
+    outputs = generate_nlcd_reclass_masks(
+        nlcd_raster_path=args.nlcd_raster,
+        reclass_table_dir=args.reclass_table_dir,
+        output_dir=args.output_dir,
+        workers=args.workers,
+        windows_per_progress_update=args.windows_per_progress_update,
+    )
+    print("Generated masks:", flush=True)
+    for output in outputs:
+        print(f"  {output}", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -121,7 +121,9 @@ def _build_output_profile(source_profile: dict) -> dict:
         count=1,
         dtype="uint8",
         nodata=OUTPUT_NODATA,
-        compress="deflate",
+        compress="zstd",
+        predictor=1,
+        zstd_level=9,
         BIGTIFF="IF_SAFER",
     )
     return output_profile

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -53,12 +53,6 @@ def _parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--nlcd-raster",
-        type=Path,
-        default=DEFAULT_NLCD_RASTER_PATH,
-        help=f"NLCD land-cover raster path. Default: {DEFAULT_NLCD_RASTER_PATH}",
-    )
-    parser.add_argument(
         "--reclass-table-dir",
         type=Path,
         default=DEFAULT_RECLASS_TABLE_DIR,
@@ -209,14 +203,12 @@ def _worker_initializer(lock: RLock) -> None:
 
 
 def _generate_mask(
-    nlcd_raster_path: Path,
     job: MaskJob,
     windows_per_progress_update: int,
 ) -> Path:
     """Generate one mask raster from one reclass table.
 
     Args:
-        nlcd_raster_path: Source NLCD land-cover raster path.
         job: Mask generation job metadata.
         windows_per_progress_update: Number of windows to process between
             progress-bar updates.
@@ -233,9 +225,11 @@ def _generate_mask(
     if job.output_path.exists():
         raise FileExistsError(f"Refusing to overwrite existing output: {job.output_path}")
 
-    with rasterio.open(nlcd_raster_path) as source:
+    with rasterio.open(DEFAULT_NLCD_RASTER_PATH) as source:
         if source.count != 1:
-            raise ValueError(f"Expected a single-band NLCD raster: {nlcd_raster_path}")
+            raise ValueError(
+                f"Expected a single-band NLCD raster: {DEFAULT_NLCD_RASTER_PATH}"
+            )
 
         output_profile = _build_output_profile(source.profile)
         block_windows = list(source.block_windows(1))
@@ -305,7 +299,6 @@ def _discover_jobs(
 
 
 def generate_nlcd_reclass_masks(
-    nlcd_raster_path: Path,
     reclass_table_dir: Path,
     output_dir: Path,
     workers: int,
@@ -314,7 +307,6 @@ def generate_nlcd_reclass_masks(
     """Generate all NLCD reclass masks in parallel.
 
     Args:
-        nlcd_raster_path: Source NLCD land-cover raster path.
         reclass_table_dir: Directory containing ``id,reclass`` CSV tables.
         output_dir: Root output directory for generated masks.
         workers: Maximum number of parallel worker processes.
@@ -328,8 +320,8 @@ def generate_nlcd_reclass_masks(
         FileNotFoundError: If the source raster does not exist.
         ValueError: If worker count or window batching settings are invalid.
     """
-    if not nlcd_raster_path.exists():
-        raise FileNotFoundError(f"NLCD raster not found: {nlcd_raster_path}")
+    if not DEFAULT_NLCD_RASTER_PATH.exists():
+        raise FileNotFoundError(f"NLCD raster not found: {DEFAULT_NLCD_RASTER_PATH}")
     if workers < 1:
         raise ValueError("Workers must be at least 1.")
     if windows_per_progress_update < 1:
@@ -339,7 +331,7 @@ def generate_nlcd_reclass_masks(
     jobs = _discover_jobs(reclass_table_dir, output_dir, timestamp)
     worker_count = min(workers, len(jobs))
 
-    print(f"NLCD raster: {nlcd_raster_path}", flush=True)
+    print(f"NLCD raster: {DEFAULT_NLCD_RASTER_PATH}", flush=True)
     print(f"Reclass tables: {reclass_table_dir}", flush=True)
     print(f"Output root: {output_dir}", flush=True)
     print(f"Workers: {worker_count:,}", flush=True)
@@ -361,7 +353,6 @@ def generate_nlcd_reclass_masks(
             futures = [
                 executor.submit(
                     _generate_mask,
-                    nlcd_raster_path,
                     job,
                     windows_per_progress_update,
                 )
@@ -378,7 +369,6 @@ def main() -> None:
     """Run the NLCD mask generation workflow."""
     args = _parse_args()
     outputs = generate_nlcd_reclass_masks(
-        nlcd_raster_path=args.nlcd_raster,
         reclass_table_dir=args.reclass_table_dir,
         output_dir=args.output_dir,
         workers=args.workers,

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -53,18 +53,6 @@ def _parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--reclass-table-dir",
-        type=Path,
-        default=DEFAULT_RECLASS_TABLE_DIR,
-        help=f"Directory containing id,reclass CSV tables. Default: {DEFAULT_RECLASS_TABLE_DIR}",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        default=DEFAULT_OUTPUT_DIR,
-        help=f"Directory where mask subdirectories will be written. Default: {DEFAULT_OUTPUT_DIR}",
-    )
-    parser.add_argument(
         "--workers",
         type=int,
         default=cpu_count() or 1,
@@ -255,15 +243,11 @@ def _generate_mask(
 
 
 def _discover_jobs(
-    reclass_table_dir: Path,
-    output_dir: Path,
     timestamp: str,
 ) -> list[MaskJob]:
     """Build mask generation jobs from all CSV tables in a directory.
 
     Args:
-        reclass_table_dir: Directory containing reclass CSV tables.
-        output_dir: Root output directory for generated masks.
         timestamp: Timestamp string to add to each output raster stem.
 
     Returns:
@@ -273,18 +257,20 @@ def _discover_jobs(
         FileNotFoundError: If the table directory does not exist.
         ValueError: If no CSV tables are found.
     """
-    if not reclass_table_dir.exists():
-        raise FileNotFoundError(f"Reclass table directory not found: {reclass_table_dir}")
+    if not DEFAULT_RECLASS_TABLE_DIR.exists():
+        raise FileNotFoundError(
+            f"Reclass table directory not found: {DEFAULT_RECLASS_TABLE_DIR}"
+        )
 
-    table_paths = sorted(reclass_table_dir.glob("*.csv"))
+    table_paths = sorted(DEFAULT_RECLASS_TABLE_DIR.glob("*.csv"))
     if not table_paths:
-        raise ValueError(f"No CSV reclass tables found in: {reclass_table_dir}")
+        raise ValueError(f"No CSV reclass tables found in: {DEFAULT_RECLASS_TABLE_DIR}")
 
     jobs = []
     for position, table_path in enumerate(table_paths, start=1):
         table_stem = table_path.stem
         output_path = (
-            output_dir
+            DEFAULT_OUTPUT_DIR
             / table_stem
             / f"reclassified_NLCD2023_{table_stem}_{timestamp}.tif"
         )
@@ -299,16 +285,12 @@ def _discover_jobs(
 
 
 def generate_nlcd_reclass_masks(
-    reclass_table_dir: Path,
-    output_dir: Path,
     workers: int,
     windows_per_progress_update: int,
 ) -> list[Path]:
     """Generate all NLCD reclass masks in parallel.
 
     Args:
-        reclass_table_dir: Directory containing ``id,reclass`` CSV tables.
-        output_dir: Root output directory for generated masks.
         workers: Maximum number of parallel worker processes.
         windows_per_progress_update: Number of block windows processed between
             each per-mask tqdm update.
@@ -328,12 +310,12 @@ def generate_nlcd_reclass_masks(
         raise ValueError("Windows per progress update must be at least 1.")
 
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    jobs = _discover_jobs(reclass_table_dir, output_dir, timestamp)
+    jobs = _discover_jobs(timestamp)
     worker_count = min(workers, len(jobs))
 
     print(f"NLCD raster: {DEFAULT_NLCD_RASTER_PATH}", flush=True)
-    print(f"Reclass tables: {reclass_table_dir}", flush=True)
-    print(f"Output root: {output_dir}", flush=True)
+    print(f"Reclass tables: {DEFAULT_RECLASS_TABLE_DIR}", flush=True)
+    print(f"Output root: {DEFAULT_OUTPUT_DIR}", flush=True)
     print(f"Workers: {worker_count:,}", flush=True)
 
     lock = RLock()
@@ -369,8 +351,6 @@ def main() -> None:
     """Run the NLCD mask generation workflow."""
     args = _parse_args()
     outputs = generate_nlcd_reclass_masks(
-        reclass_table_dir=args.reclass_table_dir,
-        output_dir=args.output_dir,
         workers=args.workers,
         windows_per_progress_update=args.windows_per_progress_update,
     )

--- a/generate_nlcd_reclass_masks.py
+++ b/generate_nlcd_reclass_masks.py
@@ -153,6 +153,8 @@ def _worker_initializer(lock: RLock) -> None:
     Args:
         lock: Multiprocessing lock shared by tqdm progress bars.
     """
+    # A shared lock plus fixed ``position`` values lets tqdm render one live bar
+    # per worker process without concurrent terminal writes scrambling output.
     tqdm.set_lock(lock)
 
 


### PR DESCRIPTION
## Summary
- Add `generate_nlcd_reclass_masks.py` to create timestamped 0/1/nodata byte masks from every CSV in `data/workflow_assets/landcover_reclass`.
- Hard-code this pipeline's NLCD raster, reclass table directory, and output mask root as module-level constants.
- Write outputs under `data/analysis_inputs/masks/{table_stem}/` with isolated per-process raster writes.
- Add `rasterio` and `pandas` to the conda environment because the new script depends on them.

Closes #23.

## Testing
- `python -m py_compile generate_nlcd_reclass_masks.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe generate_nlcd_reclass_masks.py --help`
- Direct same-process synthetic 4x4 NLCD raster run with all workflow CSV tables; generated 9 grouped timestamped masks under `output/nlcd_mask_test/masks_direct`.
- Inspected representative generated masks and confirmed byte values `[0, 1, 255]`, nodata `255`, and ZSTD compression.

## Notes
- I did not run the script against the full NLCD raster because that would generate the full mask set and may take meaningful time and disk space.
- The default NLCD path points to the organized local copy at `data/analysis_inputs/nlcd/Annual_NLCD_LndCov_2023_CU_C1V0.tif`.