### PR TITLE
Add assessment zonal statistics config

### DIFF
--- a/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
+++ b/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
@@ -1,0 +1,183 @@
+# Zonal statistics runner configuration for the SNAPP public lands assessment.
+#
+# The zonal_stats_toolkit runner reads INI-style sections from this `.yaml`
+# file. Paths are relative to this config file.
+
+[project]
+name = snapp_assessment_zonal_stats
+global_work_dir = ../../processing_outputs/zonal_stats_work
+log_level = INFO
+
+
+# Shared inputs.
+#
+# The zonal_stats_toolkit runner supports globs for raster inputs, but
+# `agg_vector` and `base_measure_vector` must be concrete paths.
+
+
+# ---------------------------------------------------------------------------
+# Counties
+# ---------------------------------------------------------------------------
+
+[job:counties_ecosystem_services]
+agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+agg_layer = tl_2024_us_county_60_states
+agg_field = GEOID
+operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
+base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
+output_csv = ../../analysis_results/zonal_stats/counties_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_stats/counties_ecosystem_services.gpkg
+
+[job:counties_masks]
+agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+agg_layer = tl_2024_us_county_60_states
+agg_field = GEOID
+operations = sum
+base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
+output_csv = ../../analysis_results/zonal_stats/counties_masks.csv
+output_gpkg = ../../analysis_results/zonal_stats/counties_masks.gpkg
+
+[job:counties_area]
+agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+agg_layer = tl_2024_us_county_60_states
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+base_measure_layer = tl_2024_us_county_60_states
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/counties_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/counties_area.gpkg
+
+[job:counties_freshwater_area]
+agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+agg_layer = tl_2024_us_county_60_states
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
+base_measure_layer = nhd_freshwater_clipped_to_usa
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/counties_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/counties_freshwater_area.gpkg
+
+[job:counties_coastline_length]
+agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
+agg_layer = tl_2024_us_county_60_states
+agg_field = GEOID
+operations = intersect_length_km
+base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
+base_measure_layer = tl_2019_us_coastline
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/counties_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_stats/counties_coastline_length.gpkg
+
+
+# ---------------------------------------------------------------------------
+# PAD-US All Lands Cut By County
+# ---------------------------------------------------------------------------
+
+[job:pad_ecosystem_services]
+agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+agg_layer = padus_all_lands_clipped_by_county
+agg_field = GEOID
+operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
+base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
+output_csv = ../../analysis_results/zonal_stats/pad_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_stats/pad_ecosystem_services.gpkg
+
+[job:pad_masks]
+agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+agg_layer = padus_all_lands_clipped_by_county
+agg_field = GEOID
+operations = sum
+base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
+output_csv = ../../analysis_results/zonal_stats/pad_masks.csv
+output_gpkg = ../../analysis_results/zonal_stats/pad_masks.gpkg
+
+[job:pad_area]
+agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+agg_layer = padus_all_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+base_measure_layer = padus_all_lands_clipped_by_county
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/pad_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/pad_area.gpkg
+
+[job:pad_freshwater_area]
+agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+agg_layer = padus_all_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
+base_measure_layer = nhd_freshwater_clipped_to_usa
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/pad_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/pad_freshwater_area.gpkg
+
+[job:pad_coastline_length]
+agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
+agg_layer = padus_all_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_length_km
+base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
+base_measure_layer = tl_2019_us_coastline
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/pad_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_stats/pad_coastline_length.gpkg
+
+
+# ---------------------------------------------------------------------------
+# PAD-US Public Lands Cut By County
+# ---------------------------------------------------------------------------
+
+[job:public_ecosystem_services]
+agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+agg_layer = padus_public_lands_clipped_by_county
+agg_field = GEOID
+operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
+base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
+output_csv = ../../analysis_results/zonal_stats/public_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_stats/public_ecosystem_services.gpkg
+
+[job:public_masks]
+agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+agg_layer = padus_public_lands_clipped_by_county
+agg_field = GEOID
+operations = sum
+base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
+output_csv = ../../analysis_results/zonal_stats/public_masks.csv
+output_gpkg = ../../analysis_results/zonal_stats/public_masks.gpkg
+
+[job:public_area]
+agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+agg_layer = padus_public_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+base_measure_layer = padus_public_lands_clipped_by_county
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/public_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/public_area.gpkg
+
+[job:public_freshwater_area]
+agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+agg_layer = padus_public_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_area_ha
+base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
+base_measure_layer = nhd_freshwater_clipped_to_usa
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/public_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_stats/public_freshwater_area.gpkg
+
+[job:public_coastline_length]
+agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
+agg_layer = padus_public_lands_clipped_by_county
+agg_field = GEOID
+operations = intersect_length_km
+base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
+base_measure_layer = tl_2019_us_coastline
+measure_crs = auto
+output_csv = ../../analysis_results/zonal_stats/public_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_stats/public_coastline_length.gpkg


### PR DESCRIPTION
## Summary

Closes #29.

Adds `data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml`, an INI-style `zonal_stats_toolkit` runner config for the SNAPP assessment metrics.

The config defines jobs for three zonal geometries:

- counties
- PAD-US all lands cut by county
- PAD-US public lands cut by county

For each zonal geometry, it configures:

- ecosystem service raster summaries: `sum`, `mean`, `stdev`, `valid_count`, `total_count`, `area_ha_valid`, `area_ha_total`
- mask raster sums
- zonal geometry area in hectares
- freshwater area in hectares
- coastline length in kilometers

One implementation note: I checked the local `zonal_stats_toolkit` runner and it supports globs for raster inputs, but `agg_vector` and `base_measure_vector` are validated with `Path.exists()`. Because of that, the config uses concrete current prepared GeoPackage paths for vector inputs and keeps glob patterns only for raster input patterns.

## Testing

- Parsed the config with Python `ConfigParser` and confirmed all 16 sections load.
- Resolved configured input paths from the config directory.
- Confirmed all concrete `agg_vector` and `base_measure_vector` paths exist.
- Confirmed raster globs resolve locally: 21 ecosystem service rasters and 9 mask rasters.
- Verified configured vector layers exist and each aggregation layer contains `GEOID`.

## Known limitations

- I did not run the full zonal statistics jobs.
- I could not call `zonal_stats_toolkit.runner.parse_and_validate_config` in this environment because importing the runner currently fails with missing `datasketches`. The config was still checked with a lightweight local parser/path/layer validation.