### PR TITLE
Clarify PAD-US preparation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ may display longer descriptions from coded-value domains. This matters for
 scripts that read the geodatabase directly: filtering should use the stored
 codes, not the displayed descriptions.
 
-The preprocessing script, `prepare_padus_lands_clipped_to_usa.py`, uses:
+The preprocessing script, `prepare_padus_all_and_public_lands.py`, uses:
 
 - Source geodatabase: `data/PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/PADUS4_1Geodatabase.gdb`
 - Source layer: `PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement`

--- a/prepare_padus_all_and_public_lands.py
+++ b/prepare_padus_all_and_public_lands.py
@@ -1,4 +1,17 @@
-"""Prepare cleaned PAD-US land layers clipped to a USA boundary."""
+"""Prepare all-land and public-land PAD-US layers clipped to the USA boundary.
+
+This script creates two cleaned PAD-US products from the same source feature
+scan:
+
+- all lands: every PAD-US feature with positive-area overlap after clipping
+- public lands: the subset of clipped PAD-US features that passes the
+  `Mang_Type` / `Own_Type` public-land rule below
+
+The public-land rule is intentionally kept in this file as plain constants and
+branching logic. If the project definition of public land changes, start with
+`KEEP_MANG_TYPES`, `KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER`, and
+`_feature_is_public`.
+"""
 
 from __future__ import annotations
 
@@ -37,7 +50,18 @@ FAILURE_STEM = "padus_lands_clipped_to_usa"
 SIMPLIFY_TOLERANCE_METERS = 15.0
 VERTICES_PER_JOB = 10000
 N_WORKERS = cpu_count()
+
+# PAD-US stores coded values in the geodatabase even when GIS software displays
+# longer descriptions. Edit these stored codes when the public-land rule changes.
+#
+# Manager rule:
+# - Keep Federal, State, Local Government, Regional Agency Special District,
+#   Joint, and Territorial managed lands in the public-land output.
 KEEP_MANG_TYPES = {"FED", "STAT", "LOC", "DIST", "JNT", "TERR"}
+
+# Owner fallback rule:
+# - If Manager Type is Unknown (`UNK`), keep features only when Owner Type is
+#   Local Government, Regional Agency Special District, Federal, Joint, or State.
 KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER = {"LOC", "DIST", "FED", "JNT", "STAT"}
 
 WORKER = {}
@@ -66,9 +90,14 @@ def _feature_is_public(feature: ogr.Feature) -> bool:
         True if the feature should be included in the public-land output.
     """
     mang_type = feature.GetField("Mang_Type")
+
+    # First preference: use manager type. These codes are the clearest signal
+    # that a feature belongs in the public-land output.
     if mang_type in KEEP_MANG_TYPES:
         return True
 
+    # Fallback: when the manager is unknown, use owner type as a secondary
+    # public-land signal. Unknown manager plus any other owner code is excluded.
     return (
         mang_type == "UNK"
         and feature.GetField("Own_Type") in KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER


### PR DESCRIPTION
## Summary

Closes #31.

Renames `prepare_padus_lands_clipped_to_usa.py` to `prepare_padus_all_and_public_lands.py` so the script name reflects that it creates both PAD-US all-land and public-land products.

Also adds comments where future public-land rule changes should start:

- module docstring now describes both outputs and points to the rule locations
- `KEEP_MANG_TYPES` and `KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER` explain the stored PAD-US code rules
- `_feature_is_public` now comments the manager-first and unknown-manager owner fallback logic
- README references the new script name

## Testing

- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile prepare_padus_all_and_public_lands.py`
- `rg "prepare_padus_lands_clipped_to_usa" -n .` returned no tracked references to the old script name

## Notes

There is an unrelated local modification to `data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml` in the worktree. It was not staged or included in this PR.