### PR TITLE
Sync release workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,70 @@
 # SNAPP Nature Assessments
 
-This repository supports a SNAPP project analyzing ecosystem services over
-public lands in the United States.
+This repository supports a SNAPP assessment of ecosystem services over land
+tenure and administrative units in the United States. The workflow prepares
+geospatial inputs, runs zonal statistics with `zonal_stats_toolkit`, and joins
+the metric-specific outputs into final county, PAD-US all-land, and PAD-US
+public-land datasets.
 
-## PAD-US Lands Preprocessing
+The preparation scripts assume commands are run from the repository root on
+Windows:
 
-The PAD-US geodatabase stores short coded values in fields, while GIS software
-may display longer descriptions from coded-value domains. This matters for
-scripts that read the geodatabase directly: filtering should use the stored
-codes, not the displayed descriptions.
+```powershell
+cd D:\repositories\snapp_nature_assesssments-
+conda env create -f environment.yml
+conda activate geo
+```
 
-The preprocessing script, `prepare_padus_all_and_public_lands.py`, uses:
+## Data Layout
 
-- Source geodatabase: `data/PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/PADUS4_1Geodatabase.gdb`
-- Source layer: `PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement`
-- USA boundary: `data/usa_vector.gpkg`
+Project data are intentionally organized by workflow role rather than by source
+download. Large data files are ignored by git.
 
-It processes PAD-US geometries once, clips them to the USA boundary, and writes
-two cleaned GeoPackage outputs:
+| Directory | Role |
+| --- | --- |
+| `data/analysis_inputs` | Inputs used directly by preprocessing or analysis jobs. This includes source rasters, source vectors, prepared masks, freshwater polygons, and county-level zonal units. |
+| `data/processing_outputs` | Intermediate products that document how analysis inputs were derived but are not final assessment deliverables. |
+| `data/workflow_assets` | Small tracked configuration files, reclassification tables, and runner configuration. |
+| `data/analysis_results/zonal_statistics` | Individual `zonal_stats_toolkit` outputs, grouped into one subdirectory per final zonal dataset. |
+| `data/analysis_results/combined` | Final joined CSV and GeoPackage deliverables. |
 
-- `output/padus_all_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg`
-- `output/padus_public_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg`
+The main analysis inputs are:
 
-Both outputs strip source PAD-US fields and keep only `land_type` plus geometry.
-The all-lands output writes `land_type = all`. The public-lands output writes
-`land_type = public`.
+| Input | Path |
+| --- | --- |
+| USA boundary | `data/analysis_inputs/boundaries/usa_boundary/usa_vector.gpkg` |
+| Counties | `data/analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg` |
+| PAD-US geodatabase | `data/analysis_inputs/padus/PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/PADUS4_1Geodatabase.gdb` |
+| Ecosystem service rasters | `data/analysis_inputs/ecosystem_services/*.tif` |
+| NLCD 2023 land cover raster | `data/analysis_inputs/nlcd/Annual_NLCD_LndCov_2023_CU_C1V0.tif` |
+| Land-cover reclassification tables | `data/workflow_assets/landcover_reclass/*.csv` |
+| NHDPlus HR geodatabase | `data/analysis_inputs/hydrography/nhdplus/NHDPlus_H_National_Release_2_GDB/NHDPlus_H_National_Release_2_GDB.gdb` |
+| Coastline | `data/analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg` |
 
-## Public-Land Rules
+## PAD-US Preparation
 
-PAD-US `Mang_Type` has the display alias `Manager Type`. Keep a feature when
-`Mang_Type` is one of these stored values:
+`prepare_padus_all_and_public_lands.py` reads the PAD-US layer
+`PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement`, clips it to the
+USA boundary, simplifies geometry with a 15 m tolerance, repairs invalid
+polygonal geometry where possible, and writes two stripped GeoPackage products:
+
+| Product | Output directory |
+| --- | --- |
+| All PAD-US lands intersecting the USA boundary | `data/processing_outputs/padus_clipped_to_usa/all_lands` |
+| Public PAD-US lands intersecting the USA boundary | `data/processing_outputs/padus_clipped_to_usa/public_lands` |
+
+Run:
+
+```powershell
+python prepare_padus_all_and_public_lands.py
+```
+
+The public-land rule is written in the script as explicit constants and in the
+`_feature_is_public` decision function. PAD-US stores coded values in the
+geodatabase even when GIS software displays longer descriptions, so filtering
+uses stored codes.
+
+Features are retained in the public-land output when `Mang_Type` is one of:
 
 | Display description | Stored value |
 | --- | --- |
@@ -40,8 +75,8 @@ PAD-US `Mang_Type` has the display alias `Manager Type`. Keep a feature when
 | Joint | `JNT` |
 | Territorial | `TERR` |
 
-If `Mang_Type` is `UNK` (`Unknown`), keep the feature only when `Own_Type`
-(`Owner Type`) is one of these stored values:
+When `Mang_Type` is `UNK` (`Unknown`), the feature is retained only when
+`Own_Type` is one of:
 
 | Display description | Stored value |
 | --- | --- |
@@ -51,18 +86,157 @@ If `Mang_Type` is `UNK` (`Unknown`), keep the feature only when `Own_Type`
 | Joint | `JNT` |
 | State | `STAT` |
 
-All other features are excluded from the public-lands output, but still appear
-in the all-lands output when their processed geometry has positive-area overlap
-with the USA boundary.
+The all-land output uses the same geometry processing, but does not apply the
+public-land attribute rule. Both products keep only `land_type` and geometry.
 
-## County Flattening
+## County Zonal Units
 
-The `cut_and_flatten_by_county.py` script cuts either clipped lands product by
-county and flattens each county to one multipolygon feature. It copies all
-non-geometry county fields and adds the input `land_type` value to each output
-feature.
+`cut_and_flatten_by_county.py` cuts a polygon input by county. For each county,
+it finds input features with positive-area intersection, intersects them with
+the county boundary, unions the pieces into one non-overlapping polygon or
+multipolygon, repairs invalid geometry where possible, and copies the county
+attributes plus the input `land_type` value.
 
-Output names are derived from the input product:
+Run the script once for each PAD-US clipped-to-USA product:
 
-- `padus_public_lands_clipped_to_usa_...gpkg` becomes `padus_public_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg`
-- `padus_all_lands_clipped_to_usa_...gpkg` becomes `padus_all_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg`
+```powershell
+python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\all_lands\padus_all_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg
+python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\public_lands\padus_public_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg
+```
+
+Outputs are written to:
+
+| Product | Output directory |
+| --- | --- |
+| PAD-US all lands by county | `data/analysis_inputs/zonal_units/padus_all_lands_by_county` |
+| PAD-US public lands by county | `data/analysis_inputs/zonal_units/padus_public_lands_by_county` |
+
+These by-county products become analysis inputs for the final zonal statistics.
+
+## Land-Cover Masks
+
+`generate_nlcd_reclass_masks.py` creates byte rasters from the NLCD 2023 land
+cover raster and the CSV tables in `data/workflow_assets/landcover_reclass`.
+Each output raster uses `1` for selected classes, `0` for unselected classes,
+and `255` for nodata. Outputs are grouped by reclassification table stem under
+`data/analysis_inputs/masks`.
+
+Run:
+
+```powershell
+python generate_nlcd_reclass_masks.py
+```
+
+The script runs one process per reclassification table, reads the NLCD raster in
+blocks, writes one output raster per table, and shows a progress bar for each
+mask.
+
+## Freshwater Preparation
+
+`prepare_nhd_freshwater_clipped_to_usa.py` prepares a simplified NHD freshwater
+polygon layer. It reads `NHDWaterbody` and `NHDArea`, keeps freshwater feature
+types, clips them to the USA boundary, simplifies with a 15 m tolerance, repairs
+invalid polygonal geometry where possible, and writes a timestamped GeoPackage
+to `data/analysis_inputs/hydrography/nhdfreshwater`.
+
+Run:
+
+```powershell
+python prepare_nhd_freshwater_clipped_to_usa.py
+```
+
+Freshwater is defined conservatively from NHD `FType` values. The included types
+are based on the USGS NHD feature domains and feature-class descriptions:
+<https://www.usgs.gov/ngp-standards-and-specifications/national-hydrography-dataset-nhd-data-dictionary-feature-domains>
+
+| Source layer | FType | Description |
+| --- | --- | --- |
+| `NHDWaterbody` | `390` | LakePond |
+| `NHDWaterbody` | `436` | Reservoir |
+| `NHDWaterbody` | `466` | SwampMarsh |
+| `NHDArea` | `460` | StreamRiver |
+| `NHDArea` | `537` | AreaOfComplexChannels |
+
+The preparation excludes saltwater, estuarine, canal, ditch, playa, and ice-mass
+classes unless the rule is changed explicitly in the script.
+
+## Zonal Statistics
+
+The zonal statistics configuration is:
+
+```text
+data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
+```
+
+The runner configuration is INI-style despite the `.yaml` extension. It runs the
+same analysis families for three zonal datasets:
+
+| Zonal dataset | Aggregation vector |
+| --- | --- |
+| Counties | `data/analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg` |
+| PAD-US all lands by county | `data/analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg` |
+| PAD-US public lands by county | `data/analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg` |
+
+The aggregation key for all jobs is `GEOID`.
+
+Before running, update the concrete timestamped paths in the configuration if
+new PAD-US by-county or NHD freshwater products have been generated. The toolkit
+supports glob patterns for rasters, but vector inputs must be concrete paths.
+
+Run from this repository root with the `zonal_stats_toolkit` environment, or an
+equivalent environment that can import the toolkit dependencies, active:
+
+```powershell
+conda activate zonal-stats-toolkit
+python D:\repositories\zonal_stats_toolkit\runner.py .\data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml
+```
+
+The configured metrics are:
+
+| Input family | Operations |
+| --- | --- |
+| Ecosystem service rasters | `sum`, `mean`, `stdev`, `valid_count`, `total_count`, `area_ha_valid`, `area_ha_total` |
+| NLCD reclassification masks | `sum` |
+| Zonal unit area | `intersect_area_ha` |
+| NHD freshwater polygons | `intersect_area_ha` |
+| Coastline | `intersect_length_km` |
+
+Outputs are written under `data/analysis_results/zonal_statistics` in three
+subdirectories: `counties`, `padus_all_lands`, and `padus_public_lands`.
+
+## Final Combination
+
+`combine_final_zonal_stats_results.py` joins the latest timestamped CSV and
+GeoPackage outputs within each zonal-statistics subdirectory. CSV files are
+joined to CSV outputs, and GeoPackage files are joined to GeoPackage outputs.
+The script keeps shared columns once and raises an error if repeated fields have
+conflicting values for the same `GEOID`.
+
+Run:
+
+```powershell
+python combine_final_zonal_stats_results.py
+```
+
+The final deliverables are written to `data/analysis_results/combined`:
+
+| Deliverable group | CSV and GeoPackage stem |
+| --- | --- |
+| Counties | `counties_combined_YYYY_MM_DD_HH_MM_SS` |
+| PAD-US all lands by county | `padus_all_lands_combined_YYYY_MM_DD_HH_MM_SS` |
+| PAD-US public lands by county | `padus_public_lands_combined_YYYY_MM_DD_HH_MM_SS` |
+
+Use `--check-gpkg-geometry` only when geometry consistency needs to be verified
+during the final join. It is slower and is disabled by default because the
+GeoPackage geometries should already match within each result group.
+
+## Runtime Notes
+
+The PAD-US, NHD, and NLCD preparation steps are the expensive parts of the
+workflow. They use process-based parallelism and report progress with `tqdm`.
+Runtime depends on disk speed, geometry complexity, and the number of CPU cores.
+
+The zonal statistics runner is also expected to be long-running because it
+summarizes multiple rasters and vector measures over three zonal datasets. The
+final combination step is comparatively light; on the local prepared outputs it
+has completed in roughly 10 to 15 seconds when geometry comparison is disabled.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,43 @@
 # SNAPP Nature Assessments
 
-This repository supports a SNAPP assessment of ecosystem services over land
-tenure and administrative units in the United States. The workflow prepares
-geospatial inputs, runs zonal statistics with `zonal_stats_toolkit`, and joins
-the metric-specific outputs into final county, PAD-US all-land, and PAD-US
-public-land datasets.
+This repository supports a SNAPP assessment of ecosystem services over counties,
+all PAD-US lands, and public PAD-US lands in the United States. The workflow
+prepares geospatial inputs, runs zonal statistics with
+[`zonal_stats_toolkit`](https://github.com/springinnovate/zonal_stats_toolkit),
+and combines the metric-specific outputs into final CSV and GeoPackage
+deliverables.
 
-The preparation scripts assume commands are run from the repository root on
-Windows:
+The input data stack is stored in this Google Drive folder:
+<https://drive.google.com/drive/folders/141tOj6sf8Go0UttVogSc_T3Jet1wXzlu>
 
-```powershell
-cd D:\repositories\snapp_nature_assesssments-
-conda env create -f environment.yml
-conda activate geo
-```
+For a local run, copy that data stack into the repository root as `data/`.
+Large data files are ignored by git; only small workflow assets such as
+configuration files and reclassification tables are tracked.
+
+## Environment
+
+The preparation scripts use the geospatial Python packages listed in
+`environment.yml`. Create that environment, or use an equivalent environment
+that includes GDAL, GeoPandas, Rasterio, Shapely 2, NumPy, Pandas, and tqdm.
+
+The zonal statistics step is run with `zonal_stats_toolkit`. See the toolkit
+repository for its current installation instructions and supported execution
+environment:
+<https://github.com/springinnovate/zonal_stats_toolkit>
 
 ## Data Layout
 
-Project data are intentionally organized by workflow role rather than by source
-download. Large data files are ignored by git.
+The `data/` directory is organized by workflow role.
 
-| Directory | Role |
+| Directory | Contents |
 | --- | --- |
 | `data/analysis_inputs` | Inputs used directly by preprocessing or analysis jobs. This includes source rasters, source vectors, prepared masks, freshwater polygons, and county-level zonal units. |
-| `data/processing_outputs` | Intermediate products that document how analysis inputs were derived but are not final assessment deliverables. |
+| `data/processing_outputs` | Intermediate products that document how analysis inputs were derived. |
 | `data/workflow_assets` | Small tracked configuration files, reclassification tables, and runner configuration. |
 | `data/analysis_results/zonal_statistics` | Individual `zonal_stats_toolkit` outputs, grouped into one subdirectory per final zonal dataset. |
 | `data/analysis_results/combined` | Final joined CSV and GeoPackage deliverables. |
 
-The main analysis inputs are:
+The main input paths are:
 
 | Input | Path |
 | --- | --- |
@@ -41,17 +50,23 @@ The main analysis inputs are:
 | NHDPlus HR geodatabase | `data/analysis_inputs/hydrography/nhdplus/NHDPlus_H_National_Release_2_GDB/NHDPlus_H_National_Release_2_GDB.gdb` |
 | Coastline | `data/analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg` |
 
-## PAD-US Preparation
+## Execution Workflow
 
-`prepare_padus_all_and_public_lands.py` reads the PAD-US layer
-`PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement`, clips it to the
-USA boundary, simplifies geometry with a 15 m tolerance, repairs invalid
-polygonal geometry where possible, and writes two stripped GeoPackage products:
+Run commands from the repository root unless otherwise noted.
 
-| Product | Output directory |
-| --- | --- |
-| All PAD-US lands intersecting the USA boundary | `data/processing_outputs/padus_clipped_to_usa/all_lands` |
-| Public PAD-US lands intersecting the USA boundary | `data/processing_outputs/padus_clipped_to_usa/public_lands` |
+### Preparation
+
+#### 1. Prepare PAD-US Lands
+
+`prepare_padus_all_and_public_lands.py` converts the PAD-US layer
+`PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement` into two
+USA-clipped GeoPackages. Geometries are simplified with a 15 m tolerance, clipped
+to the USA boundary, and repaired where possible.
+
+- `padus_all_lands_clipped_to_usa_<timestamp>.gpkg` in
+  `data/processing_outputs/padus_clipped_to_usa/all_lands`
+- `padus_public_lands_clipped_to_usa_<timestamp>.gpkg` in
+  `data/processing_outputs/padus_clipped_to_usa/public_lands`
 
 Run:
 
@@ -59,67 +74,46 @@ Run:
 python prepare_padus_all_and_public_lands.py
 ```
 
-The public-land rule is written in the script as explicit constants and in the
-`_feature_is_public` decision function. PAD-US stores coded values in the
-geodatabase even when GIS software displays longer descriptions, so filtering
-uses stored codes.
+The all-land product includes every PAD-US feature that has positive-area
+overlap with the USA boundary after processing.
 
-Features are retained in the public-land output when `Mang_Type` is one of:
+The public-land product is a subset of the all-land product. PAD-US stores
+coded values in the geodatabase even when GIS software displays longer
+descriptions, so the rule uses stored codes:
 
-| Display description | Stored value |
-| --- | --- |
-| Federal | `FED` |
-| State | `STAT` |
-| Local Government | `LOC` |
-| Regional Agency Special District | `DIST` |
-| Joint | `JNT` |
-| Territorial | `TERR` |
+- Keep features where `Mang_Type` is `FED`, `STAT`, `LOC`, `DIST`, `JNT`, or
+  `TERR`. These correspond to Federal, State, Local Government, Regional Agency
+  Special District, Joint, and Territorial managers.
+- If `Mang_Type` is `UNK`, keep the feature only when `Own_Type` is `LOC`,
+  `DIST`, `FED`, `JNT`, or `STAT`. These correspond to Local Government,
+  Regional Agency Special District, Federal, Joint, and State owners.
+- Exclude all other features from the public-land product.
 
-When `Mang_Type` is `UNK` (`Unknown`), the feature is retained only when
-`Own_Type` is one of:
+Both PAD-US products keep only `land_type` and geometry.
 
-| Display description | Stored value |
-| --- | --- |
-| Local Government | `LOC` |
-| Regional Agency Special District | `DIST` |
-| Federal | `FED` |
-| Joint | `JNT` |
-| State | `STAT` |
+#### 2. Cut PAD-US Lands By County
 
-The all-land output uses the same geometry processing, but does not apply the
-public-land attribute rule. Both products keep only `land_type` and geometry.
+`cut_and_flatten_by_county.py` converts a clipped PAD-US product into one
+feature per county. It intersects the input with county boundaries, combines the
+pieces within each county into a single non-overlapping polygon or multipolygon,
+and copies the county attributes plus `land_type`.
 
-## County Zonal Units
-
-`cut_and_flatten_by_county.py` cuts a polygon input by county. For each county,
-it finds input features with positive-area intersection, intersects them with
-the county boundary, unions the pieces into one non-overlapping polygon or
-multipolygon, repairs invalid geometry where possible, and copies the county
-attributes plus the input `land_type` value.
-
-Run the script once for each PAD-US clipped-to-USA product:
+Run the script once for all lands and once for public lands:
 
 ```powershell
-python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\all_lands\padus_all_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg
-python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\public_lands\padus_public_lands_clipped_to_usa_YYYY_MM_DD_HH_MM_SS.gpkg
+python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\all_lands\padus_all_lands_clipped_to_usa_<timestamp>.gpkg
+python cut_and_flatten_by_county.py .\data\processing_outputs\padus_clipped_to_usa\public_lands\padus_public_lands_clipped_to_usa_<timestamp>.gpkg
 ```
 
-Outputs are written to:
+The resulting by-county PAD-US products are written under
+`data/analysis_inputs/zonal_units` and become zonal units for later analysis.
 
-| Product | Output directory |
-| --- | --- |
-| PAD-US all lands by county | `data/analysis_inputs/zonal_units/padus_all_lands_by_county` |
-| PAD-US public lands by county | `data/analysis_inputs/zonal_units/padus_public_lands_by_county` |
+#### 3. Prepare Land-Cover Masks
 
-These by-county products become analysis inputs for the final zonal statistics.
-
-## Land-Cover Masks
-
-`generate_nlcd_reclass_masks.py` creates byte rasters from the NLCD 2023 land
-cover raster and the CSV tables in `data/workflow_assets/landcover_reclass`.
-Each output raster uses `1` for selected classes, `0` for unselected classes,
-and `255` for nodata. Outputs are grouped by reclassification table stem under
-`data/analysis_inputs/masks`.
+`generate_nlcd_reclass_masks.py` creates 0/1/nodata byte rasters from the NLCD
+2023 land cover raster and the CSV tables in
+`data/workflow_assets/landcover_reclass`. Outputs are grouped by
+reclassification table under `data/analysis_inputs/masks`.
 
 Run:
 
@@ -127,17 +121,12 @@ Run:
 python generate_nlcd_reclass_masks.py
 ```
 
-The script runs one process per reclassification table, reads the NLCD raster in
-blocks, writes one output raster per table, and shows a progress bar for each
-mask.
-
-## Freshwater Preparation
+#### 4. Prepare Freshwater Polygons
 
 `prepare_nhd_freshwater_clipped_to_usa.py` prepares a simplified NHD freshwater
-polygon layer. It reads `NHDWaterbody` and `NHDArea`, keeps freshwater feature
-types, clips them to the USA boundary, simplifies with a 15 m tolerance, repairs
-invalid polygonal geometry where possible, and writes a timestamped GeoPackage
-to `data/analysis_inputs/hydrography/nhdfreshwater`.
+polygon layer from `NHDWaterbody` and `NHDArea`, clips it to the USA boundary,
+and writes a timestamped GeoPackage under
+`data/analysis_inputs/hydrography/nhdfreshwater`.
 
 Run:
 
@@ -145,22 +134,17 @@ Run:
 python prepare_nhd_freshwater_clipped_to_usa.py
 ```
 
-Freshwater is defined conservatively from NHD `FType` values. The included types
-are based on the USGS NHD feature domains and feature-class descriptions:
+Freshwater is defined conservatively from NHD `FType` values using the USGS NHD
+feature domains:
 <https://www.usgs.gov/ngp-standards-and-specifications/national-hydrography-dataset-nhd-data-dictionary-feature-domains>
 
-| Source layer | FType | Description |
-| --- | --- | --- |
-| `NHDWaterbody` | `390` | LakePond |
-| `NHDWaterbody` | `436` | Reservoir |
-| `NHDWaterbody` | `466` | SwampMarsh |
-| `NHDArea` | `460` | StreamRiver |
-| `NHDArea` | `537` | AreaOfComplexChannels |
+- `NHDWaterbody`: `390` LakePond, `436` Reservoir, and `466` SwampMarsh.
+- `NHDArea`: `460` StreamRiver and `537` AreaOfComplexChannels.
 
-The preparation excludes saltwater, estuarine, canal, ditch, playa, and ice-mass
-classes unless the rule is changed explicitly in the script.
+Saltwater, estuarine, canal, ditch, playa, and ice-mass classes are not included
+unless the rule is changed explicitly in the script.
 
-## Zonal Statistics
+### Zonal Statistics
 
 The zonal statistics configuration is:
 
@@ -168,27 +152,23 @@ The zonal statistics configuration is:
 data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
 ```
 
-The runner configuration is INI-style despite the `.yaml` extension. It runs the
-same analysis families for three zonal datasets:
+Before running, update the concrete timestamped vector paths in that file if new
+PAD-US by-county or NHD freshwater products have been generated. The toolkit
+supports glob patterns for raster inputs, but vector inputs are listed as
+explicit GeoPackage paths.
 
-| Zonal dataset | Aggregation vector |
-| --- | --- |
-| Counties | `data/analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg` |
-| PAD-US all lands by county | `data/analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg` |
-| PAD-US public lands by county | `data/analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_YYYY_MM_DD_HH_MM_SS.gpkg` |
+The configuration runs the same analysis families for three zonal datasets:
 
-The aggregation key for all jobs is `GEOID`.
+- Counties, keyed by `GEOID`.
+- PAD-US all lands by county, keyed by `GEOID`.
+- PAD-US public lands by county, keyed by `GEOID`.
 
-Before running, update the concrete timestamped paths in the configuration if
-new PAD-US by-county or NHD freshwater products have been generated. The toolkit
-supports glob patterns for rasters, but vector inputs must be concrete paths.
-
-Run from this repository root with the `zonal_stats_toolkit` environment, or an
-equivalent environment that can import the toolkit dependencies, active:
+From this repository root, run the toolkit runner. Replace
+`<zonal_stats_toolkit_repo>` with the path to a local clone of
+[`zonal_stats_toolkit`](https://github.com/springinnovate/zonal_stats_toolkit):
 
 ```powershell
-conda activate zonal-stats-toolkit
-python D:\repositories\zonal_stats_toolkit\runner.py .\data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml
+python <zonal_stats_toolkit_repo>\runner.py .\data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml
 ```
 
 The configured metrics are:
@@ -201,16 +181,15 @@ The configured metrics are:
 | NHD freshwater polygons | `intersect_area_ha` |
 | Coastline | `intersect_length_km` |
 
-Outputs are written under `data/analysis_results/zonal_statistics` in three
-subdirectories: `counties`, `padus_all_lands`, and `padus_public_lands`.
+The runner writes individual timestamped outputs under
+`data/analysis_results/zonal_statistics`.
 
-## Final Combination
+### Final Combination
 
 `combine_final_zonal_stats_results.py` joins the latest timestamped CSV and
-GeoPackage outputs within each zonal-statistics subdirectory. CSV files are
-joined to CSV outputs, and GeoPackage files are joined to GeoPackage outputs.
-The script keeps shared columns once and raises an error if repeated fields have
-conflicting values for the same `GEOID`.
+GeoPackage outputs within each zonal-statistics subdirectory. Shared columns are
+kept once, and repeated fields with conflicting values for the same `GEOID`
+raise an error.
 
 Run:
 
@@ -218,17 +197,16 @@ Run:
 python combine_final_zonal_stats_results.py
 ```
 
-The final deliverables are written to `data/analysis_results/combined`:
+The final deliverables are:
 
-| Deliverable group | CSV and GeoPackage stem |
-| --- | --- |
-| Counties | `counties_combined_YYYY_MM_DD_HH_MM_SS` |
-| PAD-US all lands by county | `padus_all_lands_combined_YYYY_MM_DD_HH_MM_SS` |
-| PAD-US public lands by county | `padus_public_lands_combined_YYYY_MM_DD_HH_MM_SS` |
+- `counties_combined_<timestamp>.csv` and
+  `counties_combined_<timestamp>.gpkg`.
+- `padus_all_lands_combined_<timestamp>.csv` and
+  `padus_all_lands_combined_<timestamp>.gpkg`.
+- `padus_public_lands_combined_<timestamp>.csv` and
+  `padus_public_lands_combined_<timestamp>.gpkg`.
 
-Use `--check-gpkg-geometry` only when geometry consistency needs to be verified
-during the final join. It is slower and is disabled by default because the
-GeoPackage geometries should already match within each result group.
+By default, these files are written to `data/analysis_results/combined`.
 
 ## Runtime Notes
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ configuration files and reclassification tables are tracked.
 
 ## Environment
 
-The preparation scripts use the geospatial Python packages listed in
-`environment.yml`. Create that environment, or use an equivalent environment
-that includes GDAL, GeoPandas, Rasterio, Shapely 2, NumPy, Pandas, and tqdm.
+The preparation scripts use the conda-compatible environment defined in
+`environment.yml`. Create it from the repository root with:
+
+```powershell
+conda env create -f environment.yml
+conda activate geo
+```
+
+The environment file includes the major geospatial packages used here, including
+GDAL, GeoPandas, Rasterio, Shapely 2, NumPy, Pandas, and tqdm.
 
 The zonal statistics step is run with `zonal_stats_toolkit`. See the toolkit
 repository for its current installation instructions and supported execution
@@ -60,8 +67,9 @@ Run commands from the repository root unless otherwise noted.
 
 `prepare_padus_all_and_public_lands.py` converts the PAD-US layer
 `PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement` into two
-USA-clipped GeoPackages. Geometries are simplified with a 15 m tolerance, clipped
-to the USA boundary, and repaired where possible.
+USA-clipped GeoPackages: one all-land product and one public-land subset.
+Geometries are simplified with a 15 m tolerance, clipped to the USA boundary,
+and repaired where possible.
 
 - `padus_all_lands_clipped_to_usa_<timestamp>.gpkg` in
   `data/processing_outputs/padus_clipped_to_usa/all_lands`
@@ -168,7 +176,7 @@ From this repository root, run the toolkit runner. Replace
 [`zonal_stats_toolkit`](https://github.com/springinnovate/zonal_stats_toolkit):
 
 ```powershell
-python <zonal_stats_toolkit_repo>\runner.py .\data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml
+python <zonal_stats_toolkit_repo>\pipeline_runner.py .\data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml
 ```
 
 The configured metrics are:
@@ -210,11 +218,10 @@ By default, these files are written to `data/analysis_results/combined`.
 
 ## Runtime Notes
 
-The PAD-US, NHD, and NLCD preparation steps are the expensive parts of the
-workflow. They use process-based parallelism and report progress with `tqdm`.
-Runtime depends on disk speed, geometry complexity, and the number of CPU cores.
+The PAD-US, NHD, NLCD preparation, and zonal statistics steps are the expensive
+parts of the workflow. On the local NVMe workstation used for this work, with 32
+logical processors and 128 GB RAM, the full preparation and zonal statistics
+workflow should be expected to take a few hours.
 
-The zonal statistics runner is also expected to be long-running because it
-summarizes multiple rasters and vector measures over three zonal datasets. The
-final combination step is comparatively light; on the local prepared outputs it
-has completed in roughly 10 to 15 seconds when geometry comparison is disabled.
+The final combination step is comparatively light and should take about 10 to 15
+seconds.

--- a/combine_final_zonal_stats_results.py
+++ b/combine_final_zonal_stats_results.py
@@ -28,7 +28,7 @@ import geopandas as gpd
 import pandas as pd
 from tqdm import tqdm
 
-DEFAULT_RESULTS_DIR = Path("data/analysis_results/zonal_stats")
+DEFAULT_RESULTS_DIR = Path("data/analysis_results/zonal_statistics")
 DEFAULT_OUTPUT_DIR = Path("data/analysis_results/combined")
 JOIN_FIELD = "GEOID"
 INPUT_TIMESTAMP_FORMATS = ("%Y%m%d_%H%M%S", "%Y_%m_%d_%H_%M_%S")

--- a/cut_and_flatten_by_county.py
+++ b/cut_and_flatten_by_county.py
@@ -16,8 +16,16 @@ from tqdm import tqdm
 
 from geometry_utils import polygonal_multipolygon, repair_polygonal_geometry
 
-COUNTY_VECTOR_PATH = Path("data/tl_2024_us_county_50_states.gpkg")
-OUT_DIR = Path("output")
+COUNTY_VECTOR_PATH = Path(
+    "data/analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg"
+)
+DEFAULT_OUT_DIR = Path("data/processing_outputs/cut_by_county")
+PADUS_ALL_LANDS_OUT_DIR = Path(
+    "data/analysis_inputs/zonal_units/padus_all_lands_by_county"
+)
+PADUS_PUBLIC_LANDS_OUT_DIR = Path(
+    "data/analysis_inputs/zonal_units/padus_public_lands_by_county"
+)
 N_WORKERS = cpu_count() or 1
 TIMESTAMP_SUFFIX = re.compile(r"_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}$")
 
@@ -82,7 +90,14 @@ def _derive_output_names(input_path: Path) -> tuple[str, Path]:
         out_stem = input_stem.replace("_clipped_to_usa", "_clipped_by_county")
     else:
         out_stem = f"{input_stem}_clipped_by_county"
-    return out_stem, OUT_DIR / f"{out_stem}_{timestamp}.gpkg"
+
+    if out_stem.startswith("padus_all_lands_"):
+        out_dir = PADUS_ALL_LANDS_OUT_DIR
+    elif out_stem.startswith("padus_public_lands_"):
+        out_dir = PADUS_PUBLIC_LANDS_OUT_DIR
+    else:
+        out_dir = DEFAULT_OUT_DIR
+    return out_stem, out_dir / f"{out_stem}_{timestamp}.gpkg"
 
 
 def _process_county(
@@ -245,7 +260,7 @@ def main() -> None:
         crs=input_features.crs,
     )
 
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     output_gdf.to_file(out_path, layer=out_layer_name, driver="GPKG", index=False)
     step_bar.update()
     step_bar.close()

--- a/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
+++ b/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
@@ -1,4 +1,4 @@
-# Zonal statistics runner configuration for the SNAPP public lands assessment.
+# Zonal statistics runner configuration for the SNAPP nature assessment.
 #
 # The zonal_stats_toolkit runner reads INI-style sections from this `.yaml`
 # file. Paths are relative to this config file.

--- a/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
+++ b/data/workflow_assets/zonal_stats/snapp_assessment_zonal_stats.yaml
@@ -25,8 +25,8 @@ agg_layer = tl_2024_us_county_60_states
 agg_field = GEOID
 operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
 base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
-output_csv = ../../analysis_results/zonal_stats/counties_ecosystem_services.csv
-output_gpkg = ../../analysis_results/zonal_stats/counties_ecosystem_services.gpkg
+output_csv = ../../analysis_results/zonal_statistics/counties/counties_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_statistics/counties/counties_ecosystem_services.gpkg
 
 [job:counties_masks]
 agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
@@ -34,8 +34,8 @@ agg_layer = tl_2024_us_county_60_states
 agg_field = GEOID
 operations = sum
 base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
-output_csv = ../../analysis_results/zonal_stats/counties_masks.csv
-output_gpkg = ../../analysis_results/zonal_stats/counties_masks.gpkg
+output_csv = ../../analysis_results/zonal_statistics/counties/counties_masks.csv
+output_gpkg = ../../analysis_results/zonal_statistics/counties/counties_masks.gpkg
 
 [job:counties_area]
 agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
@@ -45,8 +45,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
 base_measure_layer = tl_2024_us_county_60_states
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/counties_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/counties_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/counties/counties_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/counties/counties_area.gpkg
 
 [job:counties_freshwater_area]
 agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
@@ -56,8 +56,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
 base_measure_layer = nhd_freshwater_clipped_to_usa
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/counties_freshwater_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/counties_freshwater_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/counties/counties_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/counties/counties_freshwater_area.gpkg
 
 [job:counties_coastline_length]
 agg_vector = ../../analysis_inputs/zonal_units/counties/tl_2024_us_county_50_states.gpkg
@@ -67,8 +67,8 @@ operations = intersect_length_km
 base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
 base_measure_layer = tl_2019_us_coastline
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/counties_coastline_length.csv
-output_gpkg = ../../analysis_results/zonal_stats/counties_coastline_length.gpkg
+output_csv = ../../analysis_results/zonal_statistics/counties/counties_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_statistics/counties/counties_coastline_length.gpkg
 
 
 # ---------------------------------------------------------------------------
@@ -81,8 +81,8 @@ agg_layer = padus_all_lands_clipped_by_county
 agg_field = GEOID
 operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
 base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
-output_csv = ../../analysis_results/zonal_stats/pad_ecosystem_services.csv
-output_gpkg = ../../analysis_results/zonal_stats/pad_ecosystem_services.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_all_lands/pad_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_all_lands/pad_ecosystem_services.gpkg
 
 [job:pad_masks]
 agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
@@ -90,8 +90,8 @@ agg_layer = padus_all_lands_clipped_by_county
 agg_field = GEOID
 operations = sum
 base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
-output_csv = ../../analysis_results/zonal_stats/pad_masks.csv
-output_gpkg = ../../analysis_results/zonal_stats/pad_masks.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_all_lands/pad_masks.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_all_lands/pad_masks.gpkg
 
 [job:pad_area]
 agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
@@ -101,8 +101,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
 base_measure_layer = padus_all_lands_clipped_by_county
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/pad_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/pad_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_all_lands/pad_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_all_lands/pad_area.gpkg
 
 [job:pad_freshwater_area]
 agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
@@ -112,8 +112,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
 base_measure_layer = nhd_freshwater_clipped_to_usa
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/pad_freshwater_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/pad_freshwater_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_all_lands/pad_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_all_lands/pad_freshwater_area.gpkg
 
 [job:pad_coastline_length]
 agg_vector = ../../analysis_inputs/zonal_units/padus_all_lands_by_county/padus_all_lands_clipped_by_county_2026_05_17_12_48_37.gpkg
@@ -123,8 +123,8 @@ operations = intersect_length_km
 base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
 base_measure_layer = tl_2019_us_coastline
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/pad_coastline_length.csv
-output_gpkg = ../../analysis_results/zonal_stats/pad_coastline_length.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_all_lands/pad_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_all_lands/pad_coastline_length.gpkg
 
 
 # ---------------------------------------------------------------------------
@@ -137,8 +137,8 @@ agg_layer = padus_public_lands_clipped_by_county
 agg_field = GEOID
 operations = sum, mean, stdev, valid_count, total_count, area_ha_valid, area_ha_total
 base_raster_pattern = ../../analysis_inputs/ecosystem_services/*.tif
-output_csv = ../../analysis_results/zonal_stats/public_ecosystem_services.csv
-output_gpkg = ../../analysis_results/zonal_stats/public_ecosystem_services.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_public_lands/public_ecosystem_services.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_public_lands/public_ecosystem_services.gpkg
 
 [job:public_masks]
 agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
@@ -146,8 +146,8 @@ agg_layer = padus_public_lands_clipped_by_county
 agg_field = GEOID
 operations = sum
 base_raster_pattern = ../../analysis_inputs/masks/*/*.tif
-output_csv = ../../analysis_results/zonal_stats/public_masks.csv
-output_gpkg = ../../analysis_results/zonal_stats/public_masks.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_public_lands/public_masks.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_public_lands/public_masks.gpkg
 
 [job:public_area]
 agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
@@ -157,8 +157,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
 base_measure_layer = padus_public_lands_clipped_by_county
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/public_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/public_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_public_lands/public_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_public_lands/public_area.gpkg
 
 [job:public_freshwater_area]
 agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
@@ -168,8 +168,8 @@ operations = intersect_area_ha
 base_measure_vector = ../../analysis_inputs/hydrography/nhdfreshwater/nhd_freshwater_clipped_to_usa_2026_05_18_01_44_14.gpkg
 base_measure_layer = nhd_freshwater_clipped_to_usa
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/public_freshwater_area.csv
-output_gpkg = ../../analysis_results/zonal_stats/public_freshwater_area.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_public_lands/public_freshwater_area.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_public_lands/public_freshwater_area.gpkg
 
 [job:public_coastline_length]
 agg_vector = ../../analysis_inputs/zonal_units/padus_public_lands_by_county/padus_public_lands_clipped_by_county_2026_05_17_12_50_19.gpkg
@@ -179,5 +179,5 @@ operations = intersect_length_km
 base_measure_vector = ../../analysis_inputs/linear_features/coastline/tl_2019_us_coastline_50_states.gpkg
 base_measure_layer = tl_2019_us_coastline
 measure_crs = auto
-output_csv = ../../analysis_results/zonal_stats/public_coastline_length.csv
-output_gpkg = ../../analysis_results/zonal_stats/public_coastline_length.gpkg
+output_csv = ../../analysis_results/zonal_statistics/padus_public_lands/public_coastline_length.csv
+output_gpkg = ../../analysis_results/zonal_statistics/padus_public_lands/public_coastline_length.gpkg

--- a/prepare_padus_all_and_public_lands.py
+++ b/prepare_padus_all_and_public_lands.py
@@ -35,14 +35,16 @@ gdal.PushErrorHandler("CPLQuietErrorHandler")
 gdal.SetConfigOption("OGR_ORGANIZE_POLYGONS", "SKIP")
 
 PADUS_GDB_PATH = Path(
-    "./data/PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/PADUS4_1Geodatabase.gdb"
+    "data/analysis_inputs/padus/"
+    "PADUS4_1Geodatabase.gdb-20260513T025718Z-3-001/"
+    "PADUS4_1Geodatabase.gdb"
 )
 PADUS_LAYER_NAME = "PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement"
-USA_BOUNDARY_PATH = Path(
-    r"D:\repositories\snapp_nature_assesssments-\data\usa_vector.gpkg"
-)
+USA_BOUNDARY_PATH = Path("data/analysis_inputs/boundaries/usa_boundary/usa_vector.gpkg")
 
-OUT_DIR = Path("output")
+OUT_DIR = Path("data/processing_outputs/padus_clipped_to_usa")
+ALL_OUT_DIR = OUT_DIR / "all_lands"
+PUBLIC_OUT_DIR = OUT_DIR / "public_lands"
 PUBLIC_OUT_STEM = "padus_public_lands_clipped_to_usa"
 ALL_OUT_STEM = "padus_all_lands_clipped_to_usa"
 FAILURE_STEM = "padus_lands_clipped_to_usa"
@@ -413,9 +415,11 @@ def main() -> None:
     # which will make the load faster then we're fixing it in this script
     # anyway
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    public_out_path = OUT_DIR / f"{PUBLIC_OUT_STEM}_{timestamp}.gpkg"
-    all_out_path = OUT_DIR / f"{ALL_OUT_STEM}_{timestamp}.gpkg"
+    public_out_path = PUBLIC_OUT_DIR / f"{PUBLIC_OUT_STEM}_{timestamp}.gpkg"
+    all_out_path = ALL_OUT_DIR / f"{ALL_OUT_STEM}_{timestamp}.gpkg"
     failure_path = OUT_DIR / f"{FAILURE_STEM}_{timestamp}_skipped.csv"
+    PUBLIC_OUT_DIR.mkdir(parents=True, exist_ok=True)
+    ALL_OUT_DIR.mkdir(parents=True, exist_ok=True)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     step_bar = tqdm(total=5, desc="PAD-US preprocessing", unit="step")


### PR DESCRIPTION
## Summary
- Rewrites the README as a methods-oriented workflow/runbook for the SNAPP assessment.
- Documents the current data layout, PAD-US public-land rule, NHD freshwater rule, preprocessing commands, zonal statistics command, and final combination deliverables.
- Syncs stale default paths in PAD-US prep, county flattening, the final combiner, and the zonal statistics configuration so they match the organized `data/analysis_inputs`, `data/processing_outputs`, and `data/analysis_results/zonal_statistics` layout.

Closes #35

## Testing
- `python -m py_compile prepare_padus_all_and_public_lands.py cut_and_flatten_by_county.py combine_final_zonal_stats_results.py generate_nlcd_reclass_masks.py prepare_nhd_freshwater_clipped_to_usa.py geometry_utils.py`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe cut_and_flatten_by_county.py --help`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe combine_final_zonal_stats_results.py --help`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe combine_final_zonal_stats_results.py --smoke-test`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -c "from pathlib import Path; import sys; sys.path.insert(0, r'D:\repositories\zonal_stats_toolkit'); import runner; cfg = runner.parse_and_validate_config(Path(r'data\workflow_assets\zonal_stats\snapp_assessment_zonal_stats.yaml')); print(len(cfg['job_list']))"`

## Notes
- The direct `python --help` checks failed in the base shell because that Python environment does not include `geopandas`; the checks passed with the `zonal-stats-toolkit` environment Python.
- Config parsing reported a GDAL warning about `GDAL_DATA` not being defined, but the config still validated as 15 jobs.
- The untracked `data_unorganized/` directory and `taskgraph_data.db` file were left untouched.