### PR TITLE
Linearize PAD-US multisurface geometries

### DIFF
--- a/prepare_padus_all_and_public_lands.py
+++ b/prepare_padus_all_and_public_lands.py
@@ -124,6 +124,24 @@ def _ogr_vertex_count(geom: ogr.Geometry) -> int:
     return count
 
 
+def _ogr_geometry_to_shapely(geom: ogr.Geometry):
+    """Convert an OGR geometry to a Shapely geometry.
+
+    PAD-US FileGDB features can be exposed as OGR `MULTISURFACE` geometries.
+    Shapely cannot read those nonlinear wrapper types from WKB, even when the
+    contents are polygonal. Linearizing with OGR first converts them to simple
+    polygonal geometry types such as `MULTIPOLYGON`.
+
+    Args:
+        geom: OGR geometry to convert.
+
+    Returns:
+        Equivalent Shapely geometry with linear OGR geometry types.
+    """
+    linear_geom = geom.GetLinearGeometry()
+    return wkb.loads(bytes(linear_geom.ExportToWkb()))
+
+
 def _read_usa_boundary(process_srs: osr.SpatialReference):
     """Read, reproject, and merge the USA boundary.
 
@@ -149,7 +167,7 @@ def _read_usa_boundary(process_srs: osr.SpatialReference):
         if transform is not None:
             geom = geom.Clone()
             geom.Transform(transform)
-        geoms.append(wkb.loads(bytes(geom.ExportToWkb())))
+        geoms.append(_ogr_geometry_to_shapely(geom))
 
     boundary_vector = None
     boundary_layer = None
@@ -287,7 +305,7 @@ def _process_job(
             if transform is not None:
                 geom = geom.Clone()
                 geom.Transform(transform)
-            shapely_geom = wkb.loads(bytes(geom.ExportToWkb()))
+            shapely_geom = _ogr_geometry_to_shapely(geom)
             if not shapely_geom.is_valid:
                 shapely_geom = repair_polygonal_geometry(shapely_geom)
                 if shapely_geom is None:


### PR DESCRIPTION
## Summary

- Adds a single OGR-to-Shapely conversion helper that calls `GetLinearGeometry()` before exporting WKB.
- Uses that helper when reading USA boundary geometries and when processing PAD-US source geometries.
- Allows PAD-US `MULTISURFACE` features to enter the existing simplify, clip, repair, and positive-area filtering workflow as linear polygonal geometries.

Resolves #41.

## Cause

PAD-US FileGDB features can be exposed by GDAL/OGR as `MULTISURFACE`. Shapely cannot read that nonlinear wrapper type from WKB, so affected features were skipped as exceptions before the all-land/public-land outputs were written. Example FID `5276` raised `Nonlinear geometry types are not currently supported` before this change.

## Testing

- `git diff --check -- prepare_padus_all_and_public_lands.py`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -m py_compile prepare_padus_all_and_public_lands.py geometry_utils.py`
- Focused validation for PAD-US FID `5276`: `_process_job([5276])` now returns `all outputs 1`, `public outputs 1`, stats `{'all_kept': 1, 'public_kept': 1}`, no failures, and a valid `MultiPolygon` with area `10022892906.670713`.

## Known Limitations

- The full PAD-US preprocessing workflow was not rerun because it is expensive; this PR validates the previously missing source feature through the same worker processing function.