### PR TITLE
Tighten PAD-US public-land rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ The public-land product is a subset of the all-land product. PAD-US stores
 coded values in the geodatabase even when GIS software displays longer
 descriptions, so the rule uses stored codes:
 
+- Before applying the inclusion rules, exclude features where `Pub_Access` is
+  `XA` (closed access), `Own_Type` is `PVT` (private owner), `Mang_Name` or
+  `Own_Name` is `DOD` or `DOE`, or `Des_Tp` is `MIL`. The `Pub_Access` value
+  `UK` (unknown access) is not excluded by itself.
 - Keep features where `Mang_Type` is `FED`, `STAT`, `LOC`, `DIST`, `JNT`, or
   `TERR`. These correspond to Federal, State, Local Government, Regional Agency
   Special District, Joint, and Territorial managers.

--- a/prepare_padus_all_and_public_lands.py
+++ b/prepare_padus_all_and_public_lands.py
@@ -9,7 +9,7 @@ scan:
 
 The public-land rule is intentionally kept in this file as plain constants and
 branching logic. If the project definition of public land changes, start with
-`KEEP_MANG_TYPES`, `KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER`, and
+`EXCLUDE_*`, `KEEP_MANG_TYPES`, `KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER`, and
 `_feature_is_public`.
 """
 
@@ -56,6 +56,16 @@ N_WORKERS = cpu_count()
 # PAD-US stores coded values in the geodatabase even when GIS software displays
 # longer descriptions. Edit these stored codes when the public-land rule changes.
 #
+# Exclusion rule:
+# - Remove closed-access, private-owned, military/defense, and Department of
+#   Energy records before applying the manager and owner inclusion rules.
+EXCLUDE_PUB_ACCESS = {"XA"}
+EXCLUDE_OWN_TYPES = {"PVT"}
+EXCLUDE_MANG_NAMES = {"DOD", "DOE"}
+EXCLUDE_OWN_NAMES = {"DOD", "DOE"}
+EXCLUDE_DES_TYPES = {"MIL"}
+
+#
 # Manager rule:
 # - Keep Federal, State, Local Government, Regional Agency Special District,
 #   Joint, and Territorial managed lands in the public-land output.
@@ -92,6 +102,20 @@ def _feature_is_public(feature: ogr.Feature) -> bool:
         True if the feature should be included in the public-land output.
     """
     mang_type = feature.GetField("Mang_Type")
+    own_type = feature.GetField("Own_Type")
+    mang_name = feature.GetField("Mang_Name")
+    own_name = feature.GetField("Own_Name")
+    des_type = feature.GetField("Des_Tp")
+    pub_access = feature.GetField("Pub_Access")
+
+    if (
+        pub_access in EXCLUDE_PUB_ACCESS
+        or own_type in EXCLUDE_OWN_TYPES
+        or mang_name in EXCLUDE_MANG_NAMES
+        or own_name in EXCLUDE_OWN_NAMES
+        or des_type in EXCLUDE_DES_TYPES
+    ):
+        return False
 
     # First preference: use manager type. These codes are the clearest signal
     # that a feature belongs in the public-land output.
@@ -100,10 +124,7 @@ def _feature_is_public(feature: ogr.Feature) -> bool:
 
     # Fallback: when the manager is unknown, use owner type as a secondary
     # public-land signal. Unknown manager plus any other owner code is excluded.
-    return (
-        mang_type == "UNK"
-        and feature.GetField("Own_Type") in KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER
-    )
+    return mang_type == "UNK" and own_type in KEEP_OWN_TYPES_WHEN_UNKNOWN_MANAGER
 
 
 def _ogr_vertex_count(geom: ogr.Geometry) -> int:


### PR DESCRIPTION
## Summary
- Add an exclusion gate before the existing PAD-US public-land inclusion rules.
- Exclude closed-access (`Pub_Access='XA'`), private-owned (`Own_Type='PVT'`), DOD/DOE, and military-designation (`Des_Tp='MIL'`) records from the public-land output.
- Document the tightened public-land rule in the README.

## Root Cause
The previous predicate accepted features as public as soon as `Mang_Type` matched a public/government manager code. That meant records with `Own_Type='PVT'`, closed access, military/defense management, or Department of Energy management could enter the public-land product before any disqualifying fields were considered.

## Testing
- `python -m py_compile prepare_padus_all_and_public_lands.py geometry_utils.py`
- `git diff --check -- prepare_padus_all_and_public_lands.py README.md`
- Validated `_feature_is_public` against representative PAD-US source features:
  - DOD/MIL Nevada Test and Training Range: excluded
  - DOE Nevada Test Site: excluded
  - BLM Kingman Field Office: retained
  - `Own_Type='PVT'` with otherwise kept manager type: excluded
  - `Pub_Access='XA'` with otherwise kept manager type: excluded
  - `Pub_Access='UK'` with otherwise valid public fields: retained

## Known Limitations
- This does not explicitly exclude `Pub_Access='UK'` unknown-access records.
- State trust / school trust treatment is unchanged and remains a separate policy decision if needed.

Resolves #45